### PR TITLE
Removed redundant 'using' statement in template

### DIFF
--- a/editor/Resources/scripttemplate.csx
+++ b/editor/Resources/scripttemplate.csx
@@ -5,7 +5,6 @@ using StorybrewCommon.Scripting;
 using StorybrewCommon.Storyboarding;
 using StorybrewCommon.Storyboarding.Util;
 using StorybrewCommon.Subtitles;
-using StorybrewCommon.Mapset;
 using StorybrewCommon.Util;
 using System;
 using System.Collections.Generic;


### PR DESCRIPTION
This is more of an excuse for me to see if starting a squeaky clean new fork branch fixes that weird committal issue.

But that redundant using statement did produce a warning sometimes upon compilation failures... So... LMAO.