### PR TITLE
Selectbox options having over 2 elements open the ContextMenu

### DIFF
--- a/common/Util/NamedValue.cs
+++ b/common/Util/NamedValue.cs
@@ -7,5 +7,10 @@ namespace StorybrewCommon.Util
     {
         public string Name;
         public object Value;
+
+        public override string ToString()
+        {
+            return Name;
+        }
     }
 }

--- a/editor/UserInterface/Selectbox.cs
+++ b/editor/UserInterface/Selectbox.cs
@@ -2,6 +2,7 @@
 using BrewLib.UserInterface.Skinning.Styles;
 using OpenTK;
 using StorybrewCommon.Util;
+using StorybrewEditor.ScreenLayers;
 using StorybrewEditor.UserInterface.Skinning.Styles;
 using System;
 
@@ -55,20 +56,24 @@ namespace StorybrewEditor.UserInterface
             button.OnClick += (sender, e) =>
             {
                 if (options == null) return;
-                var optionFound = false;
-                foreach (var option in options)
+                else if(options.Length > 2) Manager.ScreenLayerManager.ShowContextMenu("Select a value", (NamedValue optionValue) => Value = optionValue.Value, options);
+                else
                 {
-                    if (optionFound)
+                    var optionFound = false;
+                    foreach (var option in options)
                     {
-                        Value = option.Value;
-                        optionFound = false;
-                        break;
+                        if (optionFound)
+                        {
+                            Value = option.Value;
+                            optionFound = false;
+                            break;
+                        }
+                        else if (option.Value.Equals(value))
+                            optionFound = true;
                     }
-                    else if (option.Value.Equals(value))
-                        optionFound = true;
+                    if (optionFound)
+                        Value = options[0].Value;
                 }
-                if (optionFound)
-                    Value = options[0].Value;
             };
         }
 


### PR DESCRIPTION
This should make selecting between a variety of enumeration elements a lot easier (such as OsbEasing), while also preserving the Selectbox type for a Bool. In addition, it also maintains an easy assumption for a new ContextMenu by adding an override for ToString in NamedValue.

ur the best damnae