### PR TITLE
Add moving to front / moving to back layer buttons

### DIFF
--- a/editor/Storyboarding/LayerManager.cs
+++ b/editor/Storyboarding/LayerManager.cs
@@ -129,6 +129,50 @@ namespace StorybrewEditor.Storyboarding
             return true;
         }
 
+        public bool MoveToBack(EditorStoryboardLayer layer)
+        {
+            var index = layers.IndexOf(layer);
+            if(index != -1)
+            {
+                if (index == 0) return false;
+                else
+                {
+                    while(index > 0 && layer.CompareTo(layers[index - 1]) == 0)
+                    {
+                        var otherLayer = layers[index - 1];
+                        layers[index - 1] = layer;
+                        layers[index] = otherLayer;
+                        --index;
+                    }
+                }
+            }
+            else throw new InvalidOperationException($"Cannot move layer '{layer.Name}'");
+            OnLayersChanged?.Invoke(this, EventArgs.Empty);
+            return true;
+        }
+
+        public bool MoveToFront(EditorStoryboardLayer layer)
+        {
+            var index = layers.IndexOf(layer);
+            if (index != -1)
+            {
+                if (index == layers.Count - 1) return false;
+                else
+                {
+                    while (index < layers.Count - 1 && layer.CompareTo(layers[index + 1]) == 0)
+                    {
+                        var otherLayer = layers[index + 1];
+                        layers[index + 1] = layer;
+                        layers[index] = otherLayer;
+                        ++index;
+                    }
+                }
+            }
+            else throw new InvalidOperationException($"Cannot move layer '{layer.Name}'");
+            OnLayersChanged?.Invoke(this, EventArgs.Empty);
+            return true;
+        }
+
         public void Draw(DrawContext drawContext, Camera camera, Box2 bounds, float opacity)
         {
             foreach (var layer in Layers)

--- a/editor/UserInterface/Components/LayerList.cs
+++ b/editor/UserInterface/Components/LayerList.cs
@@ -92,7 +92,7 @@ namespace StorybrewEditor.UserInterface.Components
 
                 Widget layerRoot;
                 Label nameLabel, effectNameLabel;
-                Button moveUpButton, moveDownButton, diffSpecificButton, osbLayerButton, showHideButton;
+                Button moveUpButton, moveDownButton, moveToBackButton, moveToFrontButton, diffSpecificButton, osbLayerButton, showHideButton;
                 layersLayout.Add(layerRoot = new LinearLayout(Manager)
                 {
                     AnchorFrom = BoxAlignment.Centre,
@@ -169,6 +169,34 @@ namespace StorybrewEditor.UserInterface.Components
                                 },
                             },
                         },
+                        new LinearLayout(Manager)
+                        {
+                            StyleName = "condensed",
+                            CanGrow = false,
+                            Children = new Widget[]
+                            {
+                                moveToBackButton = new Button(Manager)
+                                {
+                                    StyleName = "icon",
+                                    Icon = IconFont.AngleDoubleUp,
+                                    Tooltip = "Move to Back\n(of current Osb Layer)",
+                                    AnchorFrom = BoxAlignment.Centre,
+                                    AnchorTo = BoxAlignment.Centre,
+                                    CanGrow = false,
+                                    Disabled = index == 0,
+                                },
+                                moveToFrontButton = new Button(Manager)
+                                {
+                                    StyleName = "icon",
+                                    Icon = IconFont.AngleDoubleDown,
+                                    Tooltip = "Move to Front\n(of current Osb Layer)",
+                                    AnchorFrom = BoxAlignment.Centre,
+                                    AnchorTo = BoxAlignment.Centre,
+                                    CanGrow = false,
+                                    Disabled = index == layers.Count - 1,
+                                },
+                            },
+                        },
                         showHideButton = new Button(Manager)
                         {
                             StyleName = "icon",
@@ -204,6 +232,8 @@ namespace StorybrewEditor.UserInterface.Components
 
                 moveUpButton.OnClick += (sender, e) => layerManager.MoveUp(la);
                 moveDownButton.OnClick += (sender, e) => layerManager.MoveDown(la);
+                moveToBackButton.OnClick += (sender, e) => layerManager.MoveToBack(la);
+                moveToFrontButton.OnClick += (sender, e) => layerManager.MoveToFront(la);
                 diffSpecificButton.OnClick += (sender, e) => la.DiffSpecific = !la.DiffSpecific;
                 osbLayerButton.OnClick += (sender, e) => Manager.ScreenLayerManager.ShowContextMenu("Choose an osb layer", selectedOsbLayer => la.OsbLayer = selectedOsbLayer, Project.OsbLayers);
                 showHideButton.OnValueChanged += (sender, e) => la.Visible = showHideButton.Checked;


### PR DESCRIPTION
I found this feature would have been incredibly useful to me when I was trying to get to a certain z-index for a layer, but have to manually click that arrow so many times.

I actually don't want to over-bloat the UI with more icons than necessary. I honestly would rather have something like holding a key (Ctrl?) would replace the LinearLayout for moveUpButton and moveDownButton with moveToBackButton and moveToFrontButton and upon KeyUp it would revert it back. However, I couldn't find a good way upon using OnKeyDown/OnKeyUp/OnKeyPress with replacing every moveUpButton/moveDownButton to their corresponding other.

At the least, I hope you find merit in the addition despite the UI concerns.