### PR TITLE
Add button to enable setting repeat points by dragging

### DIFF
--- a/editor/ScreenLayers/ProjectMenu.cs
+++ b/editor/ScreenLayers/ProjectMenu.cs
@@ -37,6 +37,7 @@ namespace StorybrewEditor.ScreenLayers
         private TimelineSlider timeline;
         private Button playPauseButton;
         private Button fitButton;
+        private Button repeatButton;
         private Button projectFolderButton;
         private Button mapsetFolderButton;
         private Button saveButton;
@@ -129,6 +130,15 @@ namespace StorybrewEditor.ScreenLayers
                         CanGrow = false,
                         Checkable = true,
                     },
+                    repeatButton = new Button(WidgetManager)
+                    {
+                        StyleName = "icon",
+                        Icon = IconFont.Repeat,
+                        Tooltip = "Set Repeat Points\nShortcut: Ctrl+R",
+                        AnchorFrom = BoxAlignment.Centre,
+                        CanGrow = false,
+                        Checkable = true,
+                    }
                 },
             });
 
@@ -272,6 +282,7 @@ namespace StorybrewEditor.ScreenLayers
             };
             playPauseButton.OnClick += (sender, e) => audio.Playing = !audio.Playing;
             Program.Settings.FitStoryboard.Bind(fitButton, () => resizeStoryboard());
+            repeatButton.OnClick += (sender, e) => timeline.UpdateRepeat = !timeline.UpdateRepeat;
 
             divisorButton.OnClick += (sender, e) =>
             {
@@ -336,7 +347,7 @@ namespace StorybrewEditor.ScreenLayers
                         if (prevBookmark != 0) timeline.Value = prevBookmark * 0.001f;
                     }
                     else timeline.Scroll(e.Shift ? -4 : -1);
-                    return true;
+                    return true;                    
             }
 
             if (!e.IsRepeat)
@@ -357,6 +368,13 @@ namespace StorybrewEditor.ScreenLayers
                         if (e.Control)
                         {
                             ClipboardHelper.SetText(((int)(audio.Time * 1000)).ToString());
+                            return true;
+                        }
+                        break;
+                    case Key.R:
+                        if (e.Control)
+                        {
+                            repeatButton.Click();
                             return true;
                         }
                         break;

--- a/editor/UserInterface/TimelineSlider.cs
+++ b/editor/UserInterface/TimelineSlider.cs
@@ -38,6 +38,7 @@ namespace StorybrewEditor.UserInterface
         private float repeatEnd;
         public float RepeatStart => repeatStart;
         public float RepeatEnd => repeatEnd;
+        public bool UpdateRepeat = false;
 
         public TimelineSlider(WidgetManager manager, Project project) : base(manager)
         {
@@ -288,6 +289,9 @@ namespace StorybrewEditor.UserInterface
 
         protected override void DragStart()
         {
+            if (!UpdateRepeat)
+                return;
+
             dragStart = Value;
             repeatStart = dragStart;
             repeatEnd = dragStart;
@@ -295,6 +299,9 @@ namespace StorybrewEditor.UserInterface
 
         protected override void DragUpdate()
         {
+            if (!UpdateRepeat)
+                return;
+
             var value = Value;
             if (value < dragStart)
             {


### PR DESCRIPTION
The current problem:
It's super nice to have the repeat loop out of pure convenience, but dragging the timeline just to seek through the song is very commonplace, and in doing so, we unintentionally create new repeat points that are undesired.

So here comes a toggle!

I initially implemented this by seeing if holding Control would enable/disable a repeatUpdate flag, but implementing that seems to be against the current conventions with switch-cases.

Instead, I added another UI button that updates the boolean. For convenience, I mapped it to a hotkey too (Ctrl+R).

💩 