### PR TITLE
Implements rudimentary video support

### DIFF
--- a/common/Storyboarding/OsbVideo.cs
+++ b/common/Storyboarding/OsbVideo.cs
@@ -1,0 +1,292 @@
+﻿using OpenTK;
+using StorybrewCommon.Storyboarding.Commands;
+using StorybrewCommon.Storyboarding.CommandValues;
+using StorybrewCommon.Storyboarding.Display;
+using System;
+using System.Collections.Generic;
+using System.IO;
+
+namespace StorybrewCommon.Storyboarding
+{
+    public class OsbVideo : StoryboardObject
+    {
+
+        public static readonly Vector2 DefaultPosition = new Vector2(-107, 0);
+
+        private List<ICommand> commands = new List<ICommand>();
+        private CommandGroup currentCommandGroup;
+
+        private int starttime = 0;
+        public int Starttime
+        {
+            get { return starttime; }
+            set { starttime = value; }
+        }
+
+        public string texturePath = "";
+        public string TexturePath
+        {
+            get { return texturePath; }
+            set
+            {
+                if (texturePath == value) return;
+                new FileInfo(value);
+                texturePath = value;
+            }
+        }
+        public virtual string GetTexturePathAt(double time)
+            => TexturePath;
+
+        public OsbOrigin Origin = OsbOrigin.Centre;
+
+        private Vector2 initialPosition;
+        public Vector2 InitialPosition
+        {
+            get { return initialPosition; }
+            set
+            {
+                if (initialPosition == value) return;
+                initialPosition = value;
+                moveTimeline.DefaultValue = initialPosition;
+                moveXTimeline.DefaultValue = initialPosition.X;
+                moveYTimeline.DefaultValue = initialPosition.Y;
+            }
+        }
+
+        public IEnumerable<ICommand> Commands => commands;
+        public int CommandCount => commands.Count;
+
+        private double commandsStartTime = double.MaxValue;
+        public double CommandsStartTime
+        {
+            get
+            {
+                if (commandsStartTime == double.MaxValue)
+                    refreshStartEndTimes();
+                return commandsStartTime;
+            }
+        }
+
+        private double commandsEndTime = double.MinValue;
+        public double CommandsEndTime
+        {
+            get
+            {
+                if (commandsEndTime == double.MinValue)
+                    refreshStartEndTimes();
+                return commandsEndTime;
+            }
+        }
+
+        private void refreshStartEndTimes()
+        {
+            clearStartEndTimes();
+            foreach (var command in commands)
+            {
+                if (!command.Active) continue;
+                commandsStartTime = Math.Min(commandsStartTime, command.StartTime);
+                commandsEndTime = Math.Max(commandsEndTime, command.EndTime);
+            }
+        }
+
+        private void clearStartEndTimes()
+        {
+            commandsStartTime = double.MaxValue;
+            commandsEndTime = double.MinValue;
+        }
+
+        public OsbVideo()
+        {
+            initializeDisplayValueBuilders();
+            InitialPosition = DefaultPosition;
+        }
+
+        public void Move(OsbEasing easing, double startTime, double endTime, CommandPosition startPosition, CommandPosition endPosition) => addCommand(new MoveCommand(easing, startTime, endTime, new CommandPosition(startPosition.X - 320, startPosition.Y - 240), new CommandPosition(endPosition.X - 320, endPosition.Y - 240)));
+        public void Move(OsbEasing easing, double startTime, double endTime, CommandPosition startPosition, double endX, double endY) => Move(easing, startTime, endTime, startPosition, new CommandPosition(endX, endY));
+        public void Move(OsbEasing easing, double startTime, double endTime, double startX, double startY, double endX, double endY) => Move(easing, startTime, endTime, new CommandPosition(startX, startY), new CommandPosition(endX, endY));
+        public void Move(double startTime, double endTime, CommandPosition startPosition, CommandPosition endPosition) => Move(OsbEasing.None, startTime, endTime, startPosition, endPosition);
+        public void Move(double startTime, double endTime, CommandPosition startPosition, double endX, double endY) => Move(OsbEasing.None, startTime, endTime, startPosition, endX, endY);
+        public void Move(double startTime, double endTime, double startX, double startY, double endX, double endY) => Move(OsbEasing.None, startTime, endTime, startX, startY, endX, endY);
+        public void Move(double time, CommandPosition position) => Move(OsbEasing.None, time, time, position, position);
+        public void Move(double time, double x, double y) => Move(OsbEasing.None, time, time, x, y, x, y);
+
+        public void MoveX(OsbEasing easing, double startTime, double endTime, CommandDecimal startX, CommandDecimal endX) => addCommand(new MoveXCommand(easing, startTime, endTime, startX - 320, endX - 320));
+        public void MoveX(double startTime, double endTime, CommandDecimal startX, CommandDecimal endX) => MoveX(OsbEasing.None, startTime, endTime, startX, endX);
+        public void MoveX(double time, CommandDecimal x) => MoveX(OsbEasing.None, time, time, x, x);
+
+        public void MoveY(OsbEasing easing, double startTime, double endTime, CommandDecimal startY, CommandDecimal endY) => addCommand(new MoveYCommand(easing, startTime, endTime, startY - 240, endY - 240));
+        public void MoveY(double startTime, double endTime, CommandDecimal startY, CommandDecimal endY) => MoveY(OsbEasing.None, startTime, endTime, startY, endY);
+        public void MoveY(double time, CommandDecimal y) => MoveY(OsbEasing.None, time, time, y, y);
+
+        public void Scale(OsbEasing easing, double startTime, double endTime, CommandDecimal startScale, CommandDecimal endScale) => addCommand(new ScaleCommand(easing, startTime, endTime, startScale, endScale));
+        public void Scale(double startTime, double endTime, CommandDecimal startScale, CommandDecimal endScale) => Scale(OsbEasing.None, startTime, endTime, startScale, endScale);
+        public void Scale(double time, CommandDecimal scale) => Scale(OsbEasing.None, time, time, scale, scale);
+
+        public void ScaleVec(OsbEasing easing, double startTime, double endTime, CommandScale startScale, CommandScale endScale) => addCommand(new VScaleCommand(easing, startTime, endTime, startScale, endScale));
+        public void ScaleVec(OsbEasing easing, double startTime, double endTime, CommandScale startScale, double endX, double endY) => ScaleVec(easing, startTime, endTime, startScale, new CommandScale(endX, endY));
+        public void ScaleVec(OsbEasing easing, double startTime, double endTime, double startX, double startY, double endX, double endY) => ScaleVec(easing, startTime, endTime, new CommandScale(startX, startY), new CommandScale(endX, endY));
+        public void ScaleVec(double startTime, double endTime, CommandScale startScale, CommandScale endScale) => ScaleVec(OsbEasing.None, startTime, endTime, startScale, endScale);
+        public void ScaleVec(double startTime, double endTime, CommandScale startScale, double endX, double endY) => ScaleVec(OsbEasing.None, startTime, endTime, startScale, endX, endY);
+        public void ScaleVec(double startTime, double endTime, double startX, double startY, double endX, double endY) => ScaleVec(OsbEasing.None, startTime, endTime, startX, startY, endX, endY);
+        public void ScaleVec(double time, CommandScale scale) => ScaleVec(OsbEasing.None, time, time, scale, scale);
+        public void ScaleVec(double time, double x, double y) => ScaleVec(OsbEasing.None, time, time, x, y, x, y);
+
+        public void Rotate(OsbEasing easing, double startTime, double endTime, CommandDecimal startRotation, CommandDecimal endRotation) => addCommand(new RotateCommand(easing, startTime, endTime, startRotation, endRotation));
+        public void Rotate(double startTime, double endTime, CommandDecimal startRotation, CommandDecimal endRotation) => Rotate(OsbEasing.None, startTime, endTime, startRotation, endRotation);
+        public void Rotate(double time, CommandDecimal rotation) => Rotate(OsbEasing.None, time, time, rotation, rotation);
+
+        public void Fade(OsbEasing easing, double startTime, double endTime, CommandDecimal startOpacity, CommandDecimal endOpacity) => addCommand(new FadeCommand(easing, startTime, endTime, startOpacity, endOpacity));
+        public void Fade(double startTime, double endTime, CommandDecimal startOpacity, CommandDecimal endOpacity) => Fade(OsbEasing.None, startTime, endTime, startOpacity, endOpacity);
+        public void Fade(double time, CommandDecimal opacity) => Fade(OsbEasing.None, time, time, opacity, opacity);
+
+        public void Color(OsbEasing easing, double startTime, double endTime, CommandColor startColor, CommandColor endColor) => addCommand(new ColorCommand(easing, startTime, endTime, startColor, endColor));
+        public void Color(OsbEasing easing, double startTime, double endTime, CommandColor startColor, double endRed, double endGreen, double endBlue) => Color(easing, startTime, endTime, startColor, new CommandColor(endRed, endGreen, endBlue));
+        public void Color(OsbEasing easing, double startTime, double endTime, double startRed, double startGreen, double startBlue, double endRed, double endGreen, double endBlue) => Color(easing, startTime, endTime, new CommandColor(startRed, startGreen, startBlue), new CommandColor(endRed, endGreen, endBlue));
+        public void Color(double startTime, double endTime, CommandColor startColor, CommandColor endColor) => Color(OsbEasing.None, startTime, endTime, startColor, endColor);
+        public void Color(double startTime, double endTime, CommandColor startColor, double endRed, double endGreen, double endBlue) => Color(OsbEasing.None, startTime, endTime, startColor, endRed, endGreen, endBlue);
+        public void Color(double startTime, double endTime, double startRed, double startGreen, double startBlue, double endRed, double endGreen, double endBlue) => Color(OsbEasing.None, startTime, endTime, startRed, startGreen, startBlue, endRed, endGreen, endBlue);
+        public void Color(double time, CommandColor color) => Color(OsbEasing.None, time, time, color, color);
+        public void Color(double time, double red, double green, double blue) => Color(OsbEasing.None, time, time, red, green, blue, red, green, blue);
+
+        public void ColorHsb(OsbEasing easing, double startTime, double endTime, CommandColor startColor, double endHue, double endSaturation, double endBrightness) => Color(easing, startTime, endTime, startColor, CommandColor.FromHsb(endHue, endSaturation, endBrightness));
+        public void ColorHsb(OsbEasing easing, double startTime, double endTime, double startHue, double startSaturation, double startBrightness, double endHue, double endSaturation, double endBrightness) => Color(easing, startTime, endTime, CommandColor.FromHsb(startHue, startSaturation, startBrightness), CommandColor.FromHsb(endHue, endSaturation, endBrightness));
+        public void ColorHsb(double startTime, double endTime, CommandColor startColor, double endHue, double endSaturation, double endBrightness) => ColorHsb(OsbEasing.None, startTime, endTime, startColor, endHue, endSaturation, endBrightness);
+        public void ColorHsb(double startTime, double endTime, double startHue, double startSaturation, double startBrightness, double endHue, double endSaturation, double endBrightness) => ColorHsb(OsbEasing.None, startTime, endTime, startHue, startSaturation, startBrightness, endHue, endSaturation, endBrightness);
+        public void ColorHsb(double time, double hue, double saturation, double brightness) => ColorHsb(OsbEasing.None, time, time, hue, saturation, brightness, hue, saturation, brightness);
+
+        public void Parameter(OsbEasing easing, double startTime, double endTime, CommandParameter parameter) => addCommand(new ParameterCommand(easing, startTime, endTime, parameter));
+        public void FlipH(double startTime, double endTime) => Parameter(OsbEasing.None, startTime, endTime, CommandParameter.FlipHorizontal);
+        public void FlipV(double startTime, double endTime) => Parameter(OsbEasing.None, startTime, endTime, CommandParameter.FlipVertical);
+        public void Additive(double startTime, double endTime) => Parameter(OsbEasing.None, startTime, endTime, CommandParameter.AdditiveBlending);
+
+        public LoopCommand StartLoopGroup(double startTime, int loopCount)
+        {
+            var loopCommand = new LoopCommand(startTime, loopCount);
+            addCommand(loopCommand);
+            startDisplayLoop(loopCommand);
+            return loopCommand;
+        }
+
+        public TriggerCommand StartTriggerGroup(string triggerName, double startTime, double endTime, int group = 0)
+        {
+            var triggerCommand = new TriggerCommand(triggerName, startTime, endTime, group);
+            addCommand(triggerCommand);
+            startDisplayTrigger(triggerCommand);
+            return triggerCommand;
+        }
+
+        public void EndGroup()
+        {
+            currentCommandGroup.EndGroup();
+            currentCommandGroup = null;
+
+            endDisplayComposites();
+        }
+
+        private void addCommand(ICommand command)
+        {
+            var commandGroup = command as CommandGroup;
+            if (commandGroup != null)
+            {
+                currentCommandGroup = commandGroup;
+                commands.Add(commandGroup);
+            }
+            else
+            {
+                if (currentCommandGroup != null)
+                    currentCommandGroup.Add(command);
+                else
+                    commands.Add(command);
+                addDisplayCommand(command);
+            }
+            clearStartEndTimes();
+        }
+
+        #region Display 
+
+        private List<KeyValuePair<Predicate<ICommand>, IAnimatedValueBuilder>> displayValueBuilders = new List<KeyValuePair<Predicate<ICommand>, IAnimatedValueBuilder>>();
+
+        private AnimatedValue<CommandPosition> moveTimeline = new AnimatedValue<CommandPosition>();
+        private AnimatedValue<CommandDecimal> moveXTimeline = new AnimatedValue<CommandDecimal>();
+        private AnimatedValue<CommandDecimal> moveYTimeline = new AnimatedValue<CommandDecimal>();
+        private AnimatedValue<CommandDecimal> scaleTimeline = new AnimatedValue<CommandDecimal>(1);
+        private AnimatedValue<CommandScale> scaleVecTimeline = new AnimatedValue<CommandScale>(Vector2.One);
+        private AnimatedValue<CommandDecimal> rotateTimeline = new AnimatedValue<CommandDecimal>();
+        private AnimatedValue<CommandDecimal> fadeTimeline = new AnimatedValue<CommandDecimal>(1);
+        private AnimatedValue<CommandColor> colorTimeline = new AnimatedValue<CommandColor>(CommandColor.FromRgb(255, 255, 255));
+        private AnimatedValue<CommandParameter> additiveTimeline = new AnimatedValue<CommandParameter>(CommandParameter.None);
+        private AnimatedValue<CommandParameter> flipHTimeline = new AnimatedValue<CommandParameter>(CommandParameter.None);
+        private AnimatedValue<CommandParameter> flipVTimeline = new AnimatedValue<CommandParameter>(CommandParameter.None);
+
+        public CommandPosition PositionAt(double time) => moveTimeline.HasCommands ? moveTimeline.ValueAtTime(time) : new CommandPosition(moveXTimeline.ValueAtTime(time), moveYTimeline.ValueAtTime(time));
+        public CommandScale ScaleAt(double time) => scaleVecTimeline.HasCommands ? scaleVecTimeline.ValueAtTime(time) : new CommandScale(scaleTimeline.ValueAtTime(time));
+        public CommandDecimal RotationAt(double time) => rotateTimeline.ValueAtTime(time);
+        public CommandDecimal OpacityAt(double time) => fadeTimeline.ValueAtTime(time);
+        public CommandColor ColorAt(double time) => colorTimeline.ValueAtTime(time);
+        public CommandParameter AdditiveAt(double time) => additiveTimeline.ValueAtTime(time);
+        public CommandParameter FlipHAt(double time) => flipHTimeline.ValueAtTime(time);
+        public CommandParameter FlipVAt(double time) => flipVTimeline.ValueAtTime(time);
+
+        private void initializeDisplayValueBuilders()
+        {
+            displayValueBuilders.Add(new KeyValuePair<Predicate<ICommand>, IAnimatedValueBuilder>((c) => c is MoveCommand, new AnimatedValueBuilder<CommandPosition>(moveTimeline)));
+            displayValueBuilders.Add(new KeyValuePair<Predicate<ICommand>, IAnimatedValueBuilder>((c) => c is MoveXCommand, new AnimatedValueBuilder<CommandDecimal>(moveXTimeline)));
+            displayValueBuilders.Add(new KeyValuePair<Predicate<ICommand>, IAnimatedValueBuilder>((c) => c is MoveYCommand, new AnimatedValueBuilder<CommandDecimal>(moveYTimeline)));
+            displayValueBuilders.Add(new KeyValuePair<Predicate<ICommand>, IAnimatedValueBuilder>((c) => c is ScaleCommand, new AnimatedValueBuilder<CommandDecimal>(scaleTimeline)));
+            displayValueBuilders.Add(new KeyValuePair<Predicate<ICommand>, IAnimatedValueBuilder>((c) => c is VScaleCommand, new AnimatedValueBuilder<CommandScale>(scaleVecTimeline)));
+            displayValueBuilders.Add(new KeyValuePair<Predicate<ICommand>, IAnimatedValueBuilder>((c) => c is RotateCommand, new AnimatedValueBuilder<CommandDecimal>(rotateTimeline)));
+            displayValueBuilders.Add(new KeyValuePair<Predicate<ICommand>, IAnimatedValueBuilder>((c) => c is FadeCommand, new AnimatedValueBuilder<CommandDecimal>(fadeTimeline)));
+            displayValueBuilders.Add(new KeyValuePair<Predicate<ICommand>, IAnimatedValueBuilder>((c) => c is ColorCommand, new AnimatedValueBuilder<CommandColor>(colorTimeline)));
+            displayValueBuilders.Add(new KeyValuePair<Predicate<ICommand>, IAnimatedValueBuilder>((c) => (c as ParameterCommand)?.StartValue.Type == ParameterType.AdditiveBlending, new AnimatedValueBuilder<CommandParameter>(additiveTimeline)));
+            displayValueBuilders.Add(new KeyValuePair<Predicate<ICommand>, IAnimatedValueBuilder>((c) => (c as ParameterCommand)?.StartValue.Type == ParameterType.FlipHorizontal, new AnimatedValueBuilder<CommandParameter>(flipHTimeline)));
+            displayValueBuilders.Add(new KeyValuePair<Predicate<ICommand>, IAnimatedValueBuilder>((c) => (c as ParameterCommand)?.StartValue.Type == ParameterType.FlipVertical, new AnimatedValueBuilder<CommandParameter>(flipVTimeline)));
+        }
+
+        private void addDisplayCommand(ICommand command)
+        {
+            foreach (var builders in displayValueBuilders)
+                if (builders.Key(command))
+                    builders.Value.Add(command);
+        }
+
+        private void startDisplayLoop(LoopCommand loopCommand)
+        {
+            foreach (var builders in displayValueBuilders)
+                builders.Value.StartDisplayLoop(loopCommand);
+        }
+
+        private void startDisplayTrigger(TriggerCommand triggerCommand)
+        {
+            foreach (var builders in displayValueBuilders)
+                builders.Value.StartDisplayTrigger(triggerCommand);
+        }
+
+        private void endDisplayComposites()
+        {
+            foreach (var builders in displayValueBuilders)
+                builders.Value.EndDisplayComposite();
+        }
+
+        #endregion
+
+        public bool IsActive(double time)
+            => CommandsStartTime <= time && time <= CommandsEndTime;
+
+        protected virtual void WriteHeader(TextWriter writer, ExportSettings exportSettings, OsbLayer layer) 
+            => writer.WriteLine($"Video,{starttime},\"{TexturePath}\",{InitialPosition.X.ToString(exportSettings.NumberFormat)},{InitialPosition.Y.ToString(exportSettings.NumberFormat)}");
+
+        public override double StartTime => CommandsStartTime;
+        public override double EndTime => CommandsEndTime;
+
+        public override void WriteOsb(TextWriter writer, ExportSettings exportSettings, OsbLayer layer)
+        {
+            if (commands.Count == 0)
+                return;
+
+            WriteHeader(writer, exportSettings, layer);
+            foreach (var command in commands)
+                command.WriteOsb(writer, exportSettings, 1);
+        }
+
+    }
+}

--- a/common/Storyboarding/StoryboardLayer.cs
+++ b/common/Storyboarding/StoryboardLayer.cs
@@ -20,6 +20,9 @@ namespace StorybrewCommon.Storyboarding
         public abstract OsbAnimation CreateAnimation(string path, int frameCount, int frameDelay, OsbLoopType loopType, OsbOrigin origin, Vector2 initialPosition);
         public abstract OsbAnimation CreateAnimation(string path, int frameCount, int frameDelay, OsbLoopType loopType, OsbOrigin origin = OsbOrigin.Centre);
 
+        public abstract OsbVideo CreateVideo(string path, int starttime, Vector2 initialPosition);
+        public abstract OsbVideo CreateVideo(string path, int starttime);
+
 #if DEBUG
         public abstract OsbScene3d CreateScene3d();
 #endif

--- a/common/common.csproj
+++ b/common/common.csproj
@@ -74,6 +74,7 @@
     <Compile Include="Curves\Curve.cs" />
     <Compile Include="Curves\TransformedCurve.cs" />
     <Compile Include="Mapset\OsuBreak.cs" />
+    <Compile Include="Storyboarding\OsbVideo.cs" />
     <Compile Include="Storyboarding\Util\CommandGenerator.cs" />
     <Compile Include="Storyboarding\OsbSample.cs" />
     <Compile Include="Subtitles\FontEffect.cs" />

--- a/editor/Storyboarding/EditorOsbVideo.cs
+++ b/editor/Storyboarding/EditorOsbVideo.cs
@@ -1,0 +1,75 @@
+﻿using OpenTK;
+using OpenTK.Graphics;
+using StorybrewCommon.Storyboarding;
+using BrewLib.Graphics;
+using BrewLib.Graphics.Cameras;
+using BrewLib.Graphics.Textures;
+using System.IO;
+using BrewLib.Util;
+using BrewLib.Graphics.Renderers;
+
+namespace StorybrewEditor.Storyboarding
+{
+    public class EditorOsbVideo : OsbVideo, DisplayableObject
+    {
+        public readonly static RenderStates AlphaBlendStates = new RenderStates();
+        public readonly static RenderStates AdditiveStates = new RenderStates() { BlendingFactor = new BlendingFactorState(BlendingMode.Additive), };
+
+        public void Draw(DrawContext drawContext, Camera camera, Box2 bounds, float opacity, Project project)
+            => Draw(drawContext, camera, bounds, opacity, project, this);
+
+        public static void Draw(DrawContext drawContext, Camera camera, Box2 bounds, float opacity, Project project, OsbVideo video)
+        {
+            var time = project.DisplayTime * 1000;
+            if (video.TexturePath == null || !video.IsActive(time)) return;
+
+            var fade = video.OpacityAt(time);
+            if (fade < 0.00001f) return;
+
+            var scale = (Vector2)video.ScaleAt(time);
+            if (scale.X == 0 || scale.Y == 0) return;
+            if (video.FlipHAt(time)) scale.X = -scale.X;
+            if (video.FlipVAt(time)) scale.Y = -scale.Y;
+
+            var fullPath = Path.Combine(project.MapsetPath, video.GetTexturePathAt(time));
+            Texture2d texture = null;
+            
+            try
+            {
+                texture = project.TextureContainer.Get(fullPath.Substring(0, fullPath.LastIndexOf('.')) + ".png");
+            }
+            catch (IOException)
+            {
+                // Happens when another process is writing to the file, will try again later.
+                return;
+            }
+            if (texture == null) return;
+
+            var position = video.PositionAt(time);
+            var rotation = video.RotationAt(time);
+            var color = video.ColorAt(time);
+            var finalColor = ((Color4)color).WithOpacity(opacity * fade);
+            var additive = video.AdditiveAt(time);
+
+            Vector2 origin;
+            switch (video.Origin)
+            {
+                default:
+                case OsbOrigin.TopLeft: origin = new Vector2(0, 0); break;
+                case OsbOrigin.TopCentre: origin = new Vector2(texture.Width * 0.5f, 0); break;
+                case OsbOrigin.TopRight: origin = new Vector2(texture.Width, 0); break;
+                case OsbOrigin.CentreLeft: origin = new Vector2(0, texture.Height * 0.5f); break;
+                case OsbOrigin.Centre: origin = new Vector2(texture.Width * 0.5f, texture.Height * 0.5f); break;
+                case OsbOrigin.CentreRight: origin = new Vector2(texture.Width, texture.Height * 0.5f); break;
+                case OsbOrigin.BottomLeft: origin = new Vector2(0, texture.Height); break;
+                case OsbOrigin.BottomCentre: origin = new Vector2(texture.Width * 0.5f, texture.Height); break;
+                case OsbOrigin.BottomRight: origin = new Vector2(texture.Width, texture.Height); break;
+            }
+
+            var boundsScaling = bounds.Height / 480;
+            DrawState.Prepare(drawContext.Get<SpriteRenderer>(), camera, additive ? AdditiveStates : AlphaBlendStates)
+                .Draw(texture, bounds.Left + bounds.Width * 0.5f + (position.X) * boundsScaling, bounds.Top + (position.Y + 240) * boundsScaling,
+                    origin.X, origin.Y, scale.X * boundsScaling, scale.Y * boundsScaling, rotation, finalColor);
+        }
+    }
+}

--- a/editor/Storyboarding/EditorStoryboardLayer.cs
+++ b/editor/Storyboarding/EditorStoryboardLayer.cs
@@ -118,6 +118,24 @@ namespace StorybrewEditor.Storyboarding
         public override OsbAnimation CreateAnimation(string path, int frameCount, int frameDelay, OsbLoopType loopType, OsbOrigin origin = OsbOrigin.Centre)
             => CreateAnimation(path, frameCount, frameDelay, loopType, origin, OsbSprite.DefaultPosition);
 
+
+        public override OsbVideo CreateVideo(string path, int starttime, Vector2 initialPosition)
+        {
+            var storyboardObject = new EditorOsbVideo()
+            {
+                TexturePath = path,
+                Starttime = starttime,
+                InitialPosition = initialPosition,
+            };
+            storyboardObjects.Add(storyboardObject);
+            displayableObjects.Add(storyboardObject);
+            storyboardObject.Fade(starttime, 1);
+            return storyboardObject;
+        }
+
+        public override OsbVideo CreateVideo(string path, int starttime)
+            => CreateVideo(path, starttime, OsbVideo.DefaultPosition);
+       
 #if DEBUG
         public override OsbScene3d CreateScene3d()
         {

--- a/editor/editor.csproj
+++ b/editor/editor.csproj
@@ -104,6 +104,7 @@
     <Compile Include="Processes\ProcessWorker.cs" />
     <Compile Include="Storyboarding\EditorOsbSample.cs" />
     <Compile Include="Storyboarding\EventObject.cs" />
+    <Compile Include="Storyboarding\EditorOsbVideo.cs" />
     <Compile Include="UserInterface\HsbColorPicker.cs" />
     <Compile Include="UserInterface\Selectbox.cs" />
     <Compile Include="UserInterface\Skinning\Styles\ColorPickerStyle.cs" />


### PR DESCRIPTION
It is mandatory to provide a png file with the same name and resolution as the video in order to have it being "previewed" properly in Storybrew.
Osb-files including videos this way will cause the osu! parser to edit the osb (putting the video commands in the video section and deleting commands associated with them) upon certain events:
-exporting the beatmap
-entering the Design-Editor and saving the beatmap
-untested: importing the beatmap
so maps including them have to get zipped and renamed to osz manually (the same for unpacking if it is the case there as well).
Also read here for reference: https://osu.ppy.sh/forum/t/504798