### PR TITLE
Add OsbAnimationPool

### DIFF
--- a/common/Storyboarding/Util/OsbAnimationPool.cs
+++ b/common/Storyboarding/Util/OsbAnimationPool.cs
@@ -1,0 +1,45 @@
+﻿using System;
+
+namespace StorybrewCommon.Storyboarding.Util
+{
+    public class OsbAnimationPool : OsbSpritePool
+    {
+        private int frameCount;
+        private int frameDelay;
+        private OsbLoopType loopType;
+
+        public OsbAnimationPool(StoryboardLayer layer, string path, int frameCount, int frameDelay, OsbLoopType loopType, OsbOrigin origin, Action<OsbSprite, double, double> finalizeSprite = null) : base(layer, path, origin, finalizeSprite)
+        {
+            this.frameCount = frameCount;
+            this.frameDelay = frameDelay;
+            this.loopType = loopType;
+        }
+
+        public OsbAnimationPool(StoryboardLayer layer, string path, int frameCount, int frameDelay, OsbLoopType loopType, OsbOrigin origin, bool additive) : this(layer, path, frameCount, frameDelay, loopType, origin, additive ? (sprite, startTime, endTime) => sprite.Additive(startTime, endTime) : (Action<OsbSprite, double, double>)null)
+        {
+        }
+
+        public new OsbSprite Get(double startTime, double endTime)
+        {
+            var result = (PooledSprite)null;
+            foreach (var pooledSprite in pooledSprites)
+                if (pooledSprite.EndTime < startTime
+                    && startTime < pooledSprite.StartTime + MaxPoolDuration
+                    && (result == null || pooledSprite.StartTime < result.StartTime))
+                {
+                    result = pooledSprite;
+                }
+
+            if (result != null)
+            {
+                result.EndTime = endTime;
+                return result.Sprite;
+            }
+
+            var sprite = layer.CreateAnimation(path, frameCount, frameDelay, loopType, origin);
+            pooledSprites.Add(new PooledSprite(sprite, startTime, endTime));
+            return sprite;
+        }
+
+    }
+}

--- a/common/Storyboarding/Util/OsbAnimationPool.cs
+++ b/common/Storyboarding/Util/OsbAnimationPool.cs
@@ -19,6 +19,6 @@ namespace StorybrewCommon.Storyboarding.Util
         {
         }
 
-        protected override OsbSprite createSprite(StoryboardLayer layer, string path, OsbOrigin origin) => layer.CreateAnimation(path, frameCount, frameDelay, loopType, origin);
+        protected override OsbSprite CreateSprite(StoryboardLayer layer, string path, OsbOrigin origin) => layer.CreateAnimation(path, frameCount, frameDelay, loopType, origin);
     }
 }

--- a/common/Storyboarding/Util/OsbAnimationPool.cs
+++ b/common/Storyboarding/Util/OsbAnimationPool.cs
@@ -19,27 +19,6 @@ namespace StorybrewCommon.Storyboarding.Util
         {
         }
 
-        public new OsbSprite Get(double startTime, double endTime)
-        {
-            var result = (PooledSprite)null;
-            foreach (var pooledSprite in pooledSprites)
-                if (pooledSprite.EndTime < startTime
-                    && startTime < pooledSprite.StartTime + MaxPoolDuration
-                    && (result == null || pooledSprite.StartTime < result.StartTime))
-                {
-                    result = pooledSprite;
-                }
-
-            if (result != null)
-            {
-                result.EndTime = endTime;
-                return result.Sprite;
-            }
-
-            var sprite = layer.CreateAnimation(path, frameCount, frameDelay, loopType, origin);
-            pooledSprites.Add(new PooledSprite(sprite, startTime, endTime));
-            return sprite;
-        }
-
+        protected override OsbSprite createSprite(StoryboardLayer layer, string path, OsbOrigin origin) => layer.CreateAnimation(path, frameCount, frameDelay, loopType, origin);
     }
 }

--- a/common/Storyboarding/Util/OsbSpritePool.cs
+++ b/common/Storyboarding/Util/OsbSpritePool.cs
@@ -5,10 +5,10 @@ namespace StorybrewCommon.Storyboarding.Util
 {
     public class OsbSpritePool : IDisposable
     {
-        protected StoryboardLayer layer;
-        protected string path;
-        protected OsbOrigin origin;
-        protected Action<OsbSprite, double, double> finalizeSprite;
+        private StoryboardLayer layer;
+        private string path;
+        private OsbOrigin origin;
+        private Action<OsbSprite, double, double> finalizeSprite;
 
         private List<PooledSprite> pooledSprites = new List<PooledSprite>();
 

--- a/common/Storyboarding/Util/OsbSpritePool.cs
+++ b/common/Storyboarding/Util/OsbSpritePool.cs
@@ -10,7 +10,7 @@ namespace StorybrewCommon.Storyboarding.Util
         protected OsbOrigin origin;
         protected Action<OsbSprite, double, double> finalizeSprite;
 
-        protected List<PooledSprite> pooledSprites = new List<PooledSprite>();
+        private List<PooledSprite> pooledSprites = new List<PooledSprite>();
 
         public int MaxPoolDuration = 60000;
 
@@ -44,7 +44,7 @@ namespace StorybrewCommon.Storyboarding.Util
                 return result.Sprite;
             }
 
-            var sprite = createSprite(layer, path, origin);
+            var sprite = CreateSprite(layer, path, origin);
             pooledSprites.Add(new PooledSprite(sprite, startTime, endTime));
             return sprite;
         }
@@ -61,9 +61,9 @@ namespace StorybrewCommon.Storyboarding.Util
             pooledSprites.Clear();
         }
 
-        protected virtual OsbSprite createSprite(StoryboardLayer layer, string path, OsbOrigin origin) => layer.CreateSprite(path, origin);
+        protected virtual OsbSprite CreateSprite(StoryboardLayer layer, string path, OsbOrigin origin) => layer.CreateSprite(path, origin);
 
-        protected class PooledSprite
+        private class PooledSprite
         {
             public OsbSprite Sprite;
             public double StartTime;

--- a/common/Storyboarding/Util/OsbSpritePool.cs
+++ b/common/Storyboarding/Util/OsbSpritePool.cs
@@ -44,7 +44,7 @@ namespace StorybrewCommon.Storyboarding.Util
                 return result.Sprite;
             }
 
-            var sprite = layer.CreateSprite(path, origin);
+            var sprite = createSprite(layer, path, origin);
             pooledSprites.Add(new PooledSprite(sprite, startTime, endTime));
             return sprite;
         }
@@ -60,6 +60,8 @@ namespace StorybrewCommon.Storyboarding.Util
 
             pooledSprites.Clear();
         }
+
+        protected virtual OsbSprite createSprite(StoryboardLayer layer, string path, OsbOrigin origin) => layer.CreateSprite(path, origin);
 
         protected class PooledSprite
         {

--- a/common/Storyboarding/Util/OsbSpritePool.cs
+++ b/common/Storyboarding/Util/OsbSpritePool.cs
@@ -5,12 +5,12 @@ namespace StorybrewCommon.Storyboarding.Util
 {
     public class OsbSpritePool : IDisposable
     {
-        private StoryboardLayer layer;
-        private string path;
-        private OsbOrigin origin;
-        private Action<OsbSprite, double, double> finalizeSprite;
+        protected StoryboardLayer layer;
+        protected string path;
+        protected OsbOrigin origin;
+        protected Action<OsbSprite, double, double> finalizeSprite;
 
-        private List<PooledSprite> pooledSprites = new List<PooledSprite>();
+        protected List<PooledSprite> pooledSprites = new List<PooledSprite>();
 
         public int MaxPoolDuration = 60000;
 
@@ -61,7 +61,7 @@ namespace StorybrewCommon.Storyboarding.Util
             pooledSprites.Clear();
         }
 
-        private class PooledSprite
+        protected class PooledSprite
         {
             public OsbSprite Sprite;
             public double StartTime;

--- a/common/common.csproj
+++ b/common/common.csproj
@@ -87,6 +87,7 @@
     <Compile Include="Storyboarding3d\Sprite3d.cs" />
     <Compile Include="Storyboarding\Util\CommandGenerator.cs" />
     <Compile Include="Storyboarding\OsbSample.cs" />
+    <Compile Include="Storyboarding\Util\OsbAnimationPool.cs" />
     <Compile Include="Subtitles\FontEffect.cs" />
     <Compile Include="Subtitles\FontGenerator.cs" />
     <Compile Include="Subtitles\FontOutline.cs" />


### PR DESCRIPTION
Since an ``OsbAnimation`` object is extended from ``OsbSprite``, why not be able to create a pool devoted to that?

The only thing I don't like is the fact that the new ``Get(double startTime, double endTime)`` method is basically the same thing as the ``OsbSpritePool`` method barring one line, but I don't think I can really call the base method to change any of that for me. :poop: 