### PR TITLE
Allow selecting OsbLayer when calling GetLayer

### DIFF
--- a/common/Scripting/StoryboardObjectGenerator.cs
+++ b/common/Scripting/StoryboardObjectGenerator.cs
@@ -28,7 +28,7 @@ namespace StorybrewCommon.Scripting
         /// The identifier will be shown in the editor as "Effect name (Identifier)". 
         /// Layers will be sorted by the order in which they are first retrieved.
         /// </summary>
-        public StoryboardLayer GetLayer(string identifier) => context.GetLayer(identifier);
+        public StoryboardLayer GetLayer(string identifier, OsbLayer osbLayer = OsbLayer.Background) => context.GetLayer(identifier, osbLayer);
 
         public Beatmap Beatmap => context.Beatmap;
         public Beatmap GetBeatmap(string name)

--- a/common/Storyboarding/GeneratorContext.cs
+++ b/common/Storyboarding/GeneratorContext.cs
@@ -14,7 +14,7 @@ namespace StorybrewCommon.Storyboarding
 
         public abstract Beatmap Beatmap { get; }
         public abstract IEnumerable<Beatmap> Beatmaps { get; }
-        public abstract StoryboardLayer GetLayer(string identifier);
+        public abstract StoryboardLayer GetLayer(string identifier, OsbLayer osbLayer);
 
         public abstract double AudioDuration { get; }
 

--- a/editor/Storyboarding/EditorGeneratorContext.cs
+++ b/editor/Storyboarding/EditorGeneratorContext.cs
@@ -51,10 +51,10 @@ namespace StorybrewEditor.Storyboarding
             this.watcher = watcher;
         }
 
-        public override StoryboardLayer GetLayer(string identifier)
+        public override StoryboardLayer GetLayer(string identifier, OsbLayer osbLayer = OsbLayer.Background)
         {
             var layer = EditorLayers.Find(l => l.Identifier == identifier);
-            if (layer == null) EditorLayers.Add(layer = new EditorStoryboardLayer(identifier, effect));
+            if (layer == null) EditorLayers.Add(layer = new EditorStoryboardLayer(identifier, effect, osbLayer));
             return layer;
         }
 

--- a/editor/Storyboarding/EditorStoryboardLayer.cs
+++ b/editor/Storyboarding/EditorStoryboardLayer.cs
@@ -39,7 +39,7 @@ namespace StorybrewEditor.Storyboarding
             }
         }
 
-        private OsbLayer osbLayer = OsbLayer.Background;
+        private OsbLayer osbLayer;
         public OsbLayer OsbLayer
         {
             get { return osbLayer; }
@@ -72,9 +72,10 @@ namespace StorybrewEditor.Storyboarding
         protected void RaiseChanged(string propertyName)
             => EventHelper.InvokeStrict(() => OnChanged, d => ((ChangedHandler)d)(this, new ChangedEventArgs(propertyName)));
 
-        public EditorStoryboardLayer(string identifier, Effect effect) : base(identifier)
+        public EditorStoryboardLayer(string identifier, Effect effect, OsbLayer osbLayer = OsbLayer.Background) : base(identifier)
         {
             this.effect = effect;
+            this.osbLayer = Enum.IsDefined(typeof(OsbLayer), (int)osbLayer) ? osbLayer : OsbLayer.Background;
         }
 
         private List<StoryboardObject> storyboardObjects = new List<StoryboardObject>();


### PR DESCRIPTION
When I was working on a storyboard with many effects, I wanted to have some sprites' layers go to the Foreground, but I had to manually move them to the Foreground after creating it. So that's what motivated me for this pull request.

## Testing

- Now I can just let storybrew instantiate wherever I want, like this random case here. :) ![randomtrololo](http://i.imgur.com/XjtHmCS.png)

- Similar to pre-existing behavior, if the layer already exists and hasn't been deleted, storybrew will not overwrite the current layer's location (i.e. the same behavior as with changing the value in a configurable's initialization).

- Because layers are given by an identifier for an effect, getting an existing layer but with a different ``osbLayer`` will not change the layer's location (because that happens on instantiation).

So for the case:
```csharp
                var layer = GetLayer(".", OsbLayer.Foreground);
                var slayer = GetLayer(".", OsbLayer.Background);
```

The layer will be on the ~~Background~~ **Foreground** level.

- Layers that are not defined by ``OsbLayer`` (i.e. <0 and >3) will default to ``OsbLayer.Background``.

Seems to have gone rather OK otherwise. Here's hoping you think so too.