### PR TITLE
Add button to effects tab to duplicate an effect and copy its fields.

### DIFF
--- a/editor/Properties/AssemblyInfo.cs
+++ b/editor/Properties/AssemblyInfo.cs
@@ -31,4 +31,4 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.53.*")]
+[assembly: AssemblyVersion("1.54.*")]

--- a/editor/UserInterface/Components/EffectList.cs
+++ b/editor/UserInterface/Components/EffectList.cs
@@ -217,7 +217,7 @@ namespace StorybrewEditor.UserInterface.Components
                 };
 
                 statusButton.OnClick += (sender, e) => Manager.ScreenLayerManager.ShowMessage($"Status: {ef.Status}\n\n{ef.StatusMessage}");
-                renameButton.OnClick += (sender, e) => Manager.ScreenLayerManager.ShowPrompt("Effect name", $"Pick a new name for {ef.Name}", (newName) =>
+                renameButton.OnClick += (sender, e) => Manager.ScreenLayerManager.ShowPrompt("Effect name", $"Pick a new name for {ef.Name}", ef.Name, (newName) =>
                 {
                     ef.Name = newName;
                     refreshEffects();


### PR DESCRIPTION
## Duplicate effects and copy fields button
This change implements a button in the effects tab to duplicate an effect and copy its fields automatically for the user. This change is great for productivity, as duplicating an effect in the current build involves 8 steps: `Copy all fields, click Add effect, select the base effect, click Rename Effect, type the name out, click OK, select configure effect and then Paste all fields.`

This change reduces that down to 4 steps: `Click "Duplicate effect and copy fields", rename the effect if desired, click OK and click Paste all fields . `

A button like this is extremely useful if the storyboard you are working on uses many variations of one effect. Here is how the button looks in the editor. [Demonstration](http://puu.sh/xcII1/388a5c2f68.gif)

## Rename Effect
This pull request also includes changes to the Rename Effect button to include the effects name in the text field to make renaming effects more convenient.