### PR TITLE
Optimise on Export

### DIFF
--- a/common/Storyboarding/Commands/ColorCommand.cs
+++ b/common/Storyboarding/Commands/ColorCommand.cs
@@ -14,5 +14,16 @@ namespace StorybrewCommon.Storyboarding.Commands
 
         public override CommandColor Midpoint(Command<CommandColor> endCommand, double progress)
             => StartValue + (endCommand.EndValue - StartValue) * progress;
+
+        public override IFragmentableCommand GetFragment(double startTime, double endTime)
+        {
+            if (IsFragmentable)
+            {
+                var startValue = ValueAtTime(startTime);
+                var endValue = ValueAtTime(endTime);
+                return new ColorCommand(Easing, startTime, endTime, startValue, endValue);
+            }
+            return this;
+        }
     }
 }

--- a/common/Storyboarding/Commands/Command.cs
+++ b/common/Storyboarding/Commands/Command.cs
@@ -4,7 +4,7 @@ using System.IO;
 
 namespace StorybrewCommon.Storyboarding.Commands
 {
-    public abstract class Command<TValue> : ITypedCommand<TValue>, IOffsetable
+    public abstract class Command<TValue> : ITypedCommand<TValue>, IFragmentableCommand, IOffsetable
         where TValue : CommandValue
     {
         public string Identifier { get; set; }
@@ -73,5 +73,9 @@ namespace StorybrewCommon.Storyboarding.Commands
 
         public override string ToString()
             => ToOsbString(ExportSettings.Default);
+
+        public bool IsFragmentable => (StartTime == EndTime) ? true : Easing == OsbEasing.None;
+
+        public abstract IFragmentableCommand GetFragment(double startTime, double endTime);
     }
 }

--- a/common/Storyboarding/Commands/Command.cs
+++ b/common/Storyboarding/Commands/Command.cs
@@ -1,6 +1,8 @@
 ﻿using StorybrewCommon.Animations;
 using StorybrewCommon.Storyboarding.CommandValues;
+using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 
 namespace StorybrewCommon.Storyboarding.Commands
 {
@@ -77,5 +79,14 @@ namespace StorybrewCommon.Storyboarding.Commands
         public bool IsFragmentable => (StartTime == EndTime) ? true : Easing == OsbEasing.None;
 
         public abstract IFragmentableCommand GetFragment(double startTime, double endTime);
+
+        public IEnumerable<int> GetNonFragmentableTimes() 
+        {
+            var nonFragmentableTimes = new HashSet<int>();
+            if (!IsFragmentable)
+                nonFragmentableTimes.UnionWith(Enumerable.Range((int)StartTime + 1, (int)(EndTime - StartTime - 1)));
+
+            return nonFragmentableTimes;
+        }
     }
 }

--- a/common/Storyboarding/Commands/CommandGroup.cs
+++ b/common/Storyboarding/Commands/CommandGroup.cs
@@ -5,15 +5,13 @@ using System.Runtime.Remoting.Messaging;
 
 namespace StorybrewCommon.Storyboarding.Commands
 {
-    public abstract class CommandGroup : MarshalByRefObject, ICommand, IFragmentableCommand
+    public abstract class CommandGroup : MarshalByRefObject, ICommand
     {
         private bool ended;
 
         public double StartTime { get; set; }
         public virtual double EndTime { get; set; }
         public virtual bool Active => true;
-        public bool IsFragmentable => false;
-        public IFragmentableCommand GetFragment(double startTime, double endTime) => this;
 
         private List<ICommand> commands = new List<ICommand>();
         public IEnumerable<ICommand> Commands => commands;

--- a/common/Storyboarding/Commands/CommandGroup.cs
+++ b/common/Storyboarding/Commands/CommandGroup.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Runtime.Remoting.Messaging;
 
 namespace StorybrewCommon.Storyboarding.Commands
 {

--- a/common/Storyboarding/Commands/CommandGroup.cs
+++ b/common/Storyboarding/Commands/CommandGroup.cs
@@ -1,16 +1,19 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Runtime.Remoting.Messaging;
 
 namespace StorybrewCommon.Storyboarding.Commands
 {
-    public abstract class CommandGroup : MarshalByRefObject, ICommand
+    public abstract class CommandGroup : MarshalByRefObject, ICommand, IFragmentableCommand
     {
         private bool ended;
 
         public double StartTime { get; set; }
         public virtual double EndTime { get; set; }
         public virtual bool Active => true;
+        public bool IsFragmentable => false;
+        public IFragmentableCommand GetFragment(double startTime, double endTime) => this;
 
         private List<ICommand> commands = new List<ICommand>();
         public IEnumerable<ICommand> Commands => commands;

--- a/common/Storyboarding/Commands/FadeCommand.cs
+++ b/common/Storyboarding/Commands/FadeCommand.cs
@@ -14,5 +14,16 @@ namespace StorybrewCommon.Storyboarding.Commands
 
         public override CommandDecimal Midpoint(Command<CommandDecimal> endCommand, double progress)
             => StartValue + (endCommand.EndValue - StartValue) * progress;
+
+        public override IFragmentableCommand GetFragment(double startTime, double endTime)
+        {
+            if (IsFragmentable)
+            {
+                var startValue = ValueAtTime(startTime);
+                var endValue = ValueAtTime(endTime);
+                return new FadeCommand(Easing, startTime, endTime, startValue, endValue);
+            }
+            return this;
+        }
     }
 }

--- a/common/Storyboarding/Commands/IFragmentableCommand.cs
+++ b/common/Storyboarding/Commands/IFragmentableCommand.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Security.Policy;
 using System.Text;
 using System.Threading.Tasks;
 
@@ -10,5 +11,6 @@ namespace StorybrewCommon.Storyboarding.Commands
     {
         bool IsFragmentable { get; }
         IFragmentableCommand GetFragment(double startTime, double endTime);
+        IEnumerable<int> GetNonFragmentableTimes();
     }
 }

--- a/common/Storyboarding/Commands/IFragmentableCommand.cs
+++ b/common/Storyboarding/Commands/IFragmentableCommand.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace StorybrewCommon.Storyboarding.Commands
+{
+    public interface IFragmentableCommand : ICommand
+    {
+        bool IsFragmentable { get; }
+        IFragmentableCommand GetFragment(double startTime, double endTime);
+    }
+}

--- a/common/Storyboarding/Commands/MoveCommand.cs
+++ b/common/Storyboarding/Commands/MoveCommand.cs
@@ -14,5 +14,16 @@ namespace StorybrewCommon.Storyboarding.Commands
 
         public override CommandPosition Midpoint(Command<CommandPosition> endCommand, double progress)
             => new CommandPosition(StartValue.X + (endCommand.EndValue.X - StartValue.X) * progress, StartValue.Y + (endCommand.EndValue.Y - StartValue.Y) * progress);
+
+        public override IFragmentableCommand GetFragment(double startTime, double endTime)
+        {
+            if (IsFragmentable)
+            {
+                var startValue = ValueAtTime(startTime);
+                var endValue = ValueAtTime(endTime);
+                return new MoveCommand(Easing, startTime, endTime, startValue, endValue);
+            }
+            return this;
+        }
     }
 }

--- a/common/Storyboarding/Commands/MoveXCommand.cs
+++ b/common/Storyboarding/Commands/MoveXCommand.cs
@@ -14,5 +14,16 @@ namespace StorybrewCommon.Storyboarding.Commands
 
         public override CommandDecimal Midpoint(Command<CommandDecimal> endCommand, double progress)
             => StartValue + (endCommand.EndValue - StartValue) * progress;
+
+        public override IFragmentableCommand GetFragment(double startTime, double endTime)
+        {
+            if (IsFragmentable)
+            {
+                var startValue = ValueAtTime(startTime);
+                var endValue = ValueAtTime(endTime);
+                return new MoveXCommand(Easing, startTime, endTime, startValue, endValue);
+            }
+            return this;
+        }
     }
 }

--- a/common/Storyboarding/Commands/MoveYCommand.cs
+++ b/common/Storyboarding/Commands/MoveYCommand.cs
@@ -14,5 +14,16 @@ namespace StorybrewCommon.Storyboarding.Commands
 
         public override CommandDecimal Midpoint(Command<CommandDecimal> endCommand, double progress)
             => StartValue + (endCommand.EndValue - StartValue) * progress;
+
+        public override IFragmentableCommand GetFragment(double startTime, double endTime)
+        {
+            if (IsFragmentable)
+            {
+                var startValue = ValueAtTime(startTime);
+                var endValue = ValueAtTime(endTime);
+                return new MoveYCommand(Easing, startTime, endTime, startValue, endValue);
+            }
+            return this;
+        }
     }
 }

--- a/common/Storyboarding/Commands/ParameterCommand.cs
+++ b/common/Storyboarding/Commands/ParameterCommand.cs
@@ -14,5 +14,11 @@ namespace StorybrewCommon.Storyboarding.Commands
 
         public override CommandParameter Midpoint(Command<CommandParameter> endCommand, double progress)
             => StartValue;
+
+        public override IFragmentableCommand GetFragment(double startTime, double endTime)
+        {
+            var startValue = ValueAtTime(startTime);
+            return new ParameterCommand(Easing, startTime, endTime, startValue);
+        }
     }
 }

--- a/common/Storyboarding/Commands/RotateCommand.cs
+++ b/common/Storyboarding/Commands/RotateCommand.cs
@@ -14,5 +14,16 @@ namespace StorybrewCommon.Storyboarding.Commands
 
         public override CommandDecimal Midpoint(Command<CommandDecimal> endCommand, double progress)
             => StartValue + (endCommand.EndValue - StartValue) * progress;
+
+        public override IFragmentableCommand GetFragment(double startTime, double endTime)
+        {
+            if (IsFragmentable)
+            {
+                var startValue = ValueAtTime(startTime);
+                var endValue = ValueAtTime(endTime);
+                return new RotateCommand(Easing, startTime, endTime, startValue, endValue);
+            }
+            return this;
+        }
     }
 }

--- a/common/Storyboarding/Commands/ScaleCommand.cs
+++ b/common/Storyboarding/Commands/ScaleCommand.cs
@@ -14,5 +14,16 @@ namespace StorybrewCommon.Storyboarding.Commands
 
         public override CommandDecimal Midpoint(Command<CommandDecimal> endCommand, double progress)
             => StartValue + (endCommand.EndValue - StartValue) * progress;
+
+        public override IFragmentableCommand GetFragment(double startTime, double endTime)
+        {
+            if (IsFragmentable)
+            {
+                var startValue = ValueAtTime(startTime);
+                var endValue = ValueAtTime(endTime);
+                return new ScaleCommand(Easing, startTime, endTime, startValue, endValue);
+            }
+            return this;
+        }
     }
 }

--- a/common/Storyboarding/Commands/VScaleCommand.cs
+++ b/common/Storyboarding/Commands/VScaleCommand.cs
@@ -14,5 +14,16 @@ namespace StorybrewCommon.Storyboarding.Commands
 
         public override CommandScale Midpoint(Command<CommandScale> endCommand, double progress)
             => new CommandScale(StartValue.X + (endCommand.EndValue.X - StartValue.X) * progress, StartValue.Y + (endCommand.EndValue.Y - StartValue.Y) * progress);
+
+        public override IFragmentableCommand GetFragment(double startTime, double endTime)
+        {
+            if (IsFragmentable)
+            {
+                var startValue = ValueAtTime(startTime);
+                var endValue = ValueAtTime(endTime);
+                return new VScaleCommand(Easing, startTime, endTime, startValue, endValue);
+            }
+            return this;
+        }
     }
 }

--- a/common/Storyboarding/Display/AnimatedValue.cs
+++ b/common/Storyboarding/Display/AnimatedValue.cs
@@ -16,7 +16,7 @@ namespace StorybrewCommon.Storyboarding.Display
         public IEnumerable<ITypedCommand<TValue>> Commands => commands;
         public bool HasCommands => commands.Count > 0;
 
-        private bool hasOverlap;
+        public bool HasOverlap { get; private set; }
 
         public double StartTime => commands.Count > 0 ? commands[0].StartTime : 0;
         public double EndTime => commands.Count > 0 ? commands[commands.Count - 1].EndTime : 0;
@@ -52,12 +52,12 @@ namespace StorybrewCommon.Storyboarding.Display
 
                 if (index > 0 && command.StartTime < commands[index - 1].EndTime)
                 {
-                    hasOverlap = true;
+                    HasOverlap = true;
                     //Debug.Print($"'{command}' overlaps existing previous command '{commands[index - 1]}'");
                 }
                 else if (index < commands.Count && commands[index].StartTime < command.EndTime)
                 {
-                    hasOverlap = true;
+                    HasOverlap = true;
                     //Debug.Print($"'{command}' overlaps existing next command '{commands[index]}'");
                 }
 
@@ -85,7 +85,7 @@ namespace StorybrewCommon.Storyboarding.Display
             if (!findCommandIndex(time, out int index) && index > 0)
                 index--;
 
-            if (hasOverlap)
+            if (HasOverlap)
                 for (var i = 0; i < index; i++)
                     if (time < commands[i].EndTime)
                     {

--- a/common/Storyboarding/ExportSettings.cs
+++ b/common/Storyboarding/ExportSettings.cs
@@ -13,6 +13,9 @@ namespace StorybrewCommon.Storyboarding
 
         public readonly NumberFormatInfo NumberFormat = new CultureInfo(@"en-US", false).NumberFormat;
 
-        public bool WriteToFile = true;
+        /// <summary>
+        /// Enables optimisation for OsbSprites that have a MaxCommandCount > 0
+        /// </summary>
+        public bool OptimiseSprites = true;
     }
 }

--- a/common/Storyboarding/ExportSettings.cs
+++ b/common/Storyboarding/ExportSettings.cs
@@ -12,5 +12,7 @@ namespace StorybrewCommon.Storyboarding
         public bool UseFloatForMove = true;
 
         public readonly NumberFormatInfo NumberFormat = new CultureInfo(@"en-US", false).NumberFormat;
+
+        public bool WriteToFile = true;
     }
 }

--- a/common/Storyboarding/OsbAnimation.cs
+++ b/common/Storyboarding/OsbAnimation.cs
@@ -8,6 +8,8 @@ namespace StorybrewCommon.Storyboarding
         public int FrameCount;
         public double FrameDelay;
         public OsbLoopType LoopType;
+        public double LoopDuration => FrameCount * FrameDelay;
+        public double AnimationEndTime => (LoopType == OsbLoopType.LoopOnce) ? StartTime + LoopDuration : EndTime;
 
         public override string GetTexturePathAt(double time)
         {

--- a/common/Storyboarding/OsbAnimation.cs
+++ b/common/Storyboarding/OsbAnimation.cs
@@ -33,22 +33,5 @@ namespace StorybrewCommon.Storyboarding
             }
             return Math.Max(0, (int)frame);
         }
-
-        public override void WriteOsb(TextWriter writer, ExportSettings exportSettings, OsbLayer layer)
-        {
-            if (CommandCount == 0)
-                return;
-
-            var osbSpriteWriter = new OsbAnimationWriter(this, MoveTimeline,
-                                                               MoveXTimeline,
-                                                               MoveYTimeline,
-                                                               ScaleTimeline,
-                                                               ScaleVecTimeline,
-                                                               RotateTimeline,
-                                                               FadeTimeline,
-                                                               ColorTimeline,
-                                                               writer, exportSettings, layer);
-            osbSpriteWriter.WriteOsb();
-        }
     }
 }

--- a/common/Storyboarding/OsbAnimation.cs
+++ b/common/Storyboarding/OsbAnimation.cs
@@ -36,15 +36,15 @@ namespace StorybrewCommon.Storyboarding
 
         public override void WriteOsb(TextWriter writer, ExportSettings exportSettings, OsbLayer layer)
         {
-            OsbAnimationWriter osbSpriteWriter = new OsbAnimationWriter(this, moveTimeline,
-                                                                        moveXTimeline,
-                                                                        moveYTimeline,
-                                                                        scaleTimeline,
-                                                                        scaleVecTimeline,
-                                                                        rotateTimeline,
-                                                                        fadeTimeline,
-                                                                        colorTimeline,
-                                                                        writer, exportSettings, layer);
+            var osbSpriteWriter = new OsbAnimationWriter(this, MoveTimeline,
+                                                               MoveXTimeline,
+                                                               MoveYTimeline,
+                                                               ScaleTimeline,
+                                                               ScaleVecTimeline,
+                                                               RotateTimeline,
+                                                               FadeTimeline,
+                                                               ColorTimeline,
+                                                               writer, exportSettings, layer);
             osbSpriteWriter.WriteOsb();
         }
     }

--- a/common/Storyboarding/OsbAnimation.cs
+++ b/common/Storyboarding/OsbAnimation.cs
@@ -32,7 +32,18 @@ namespace StorybrewCommon.Storyboarding
             return Math.Max(0, (int)frame);
         }
 
-        protected override void WriteHeader(TextWriter writer, ExportSettings exportSettings, OsbLayer layer)
-            => writer.WriteLine($"Animation,{layer},{Origin.ToString()},\"{TexturePath.Trim()}\",{InitialPosition.X.ToString(exportSettings.NumberFormat)},{InitialPosition.Y.ToString(exportSettings.NumberFormat)},{FrameCount},{FrameDelay.ToString(exportSettings.NumberFormat)},{LoopType}");
+        public override void WriteOsb(TextWriter writer, ExportSettings exportSettings, OsbLayer layer)
+        {
+            OsbAnimationWriter osbSpriteWriter = new OsbAnimationWriter(this, moveTimeline,
+                                                                        moveXTimeline,
+                                                                        moveYTimeline,
+                                                                        scaleTimeline,
+                                                                        scaleVecTimeline,
+                                                                        rotateTimeline,
+                                                                        fadeTimeline,
+                                                                        colorTimeline,
+                                                                        writer, exportSettings, layer);
+            osbSpriteWriter.WriteOsb();
+        }
     }
 }

--- a/common/Storyboarding/OsbAnimation.cs
+++ b/common/Storyboarding/OsbAnimation.cs
@@ -36,6 +36,9 @@ namespace StorybrewCommon.Storyboarding
 
         public override void WriteOsb(TextWriter writer, ExportSettings exportSettings, OsbLayer layer)
         {
+            if (CommandCount == 0)
+                return;
+
             var osbSpriteWriter = new OsbAnimationWriter(this, MoveTimeline,
                                                                MoveXTimeline,
                                                                MoveYTimeline,

--- a/common/Storyboarding/OsbAnimationWriter.cs
+++ b/common/Storyboarding/OsbAnimationWriter.cs
@@ -73,11 +73,15 @@ namespace StorybrewCommon.Storyboarding
             HashSet<int> fragmentationTimes = base.GetFragmentationTimes();
 
             int tMax = fragmentationTimes.Max();
+            HashSet<int> nonFragmentableTimes = new HashSet<int>();
 
             for (double d = OsbAnimation.StartTime; d < OsbAnimation.AnimationEndtime(); d += OsbAnimation.LoopDuration())
             {
-                fragmentationTimes.RemoveWhere(t => t > d && t < d + OsbAnimation.LoopDuration() && t < tMax);
+                var range = Enumerable.Range((int)d + 1, (int)(OsbAnimation.LoopDuration() - 1));
+                nonFragmentableTimes.UnionWith(range);
             }
+
+            fragmentationTimes.RemoveWhere(t => nonFragmentableTimes.Contains(t) && t < tMax);
 
             return fragmentationTimes;
         }

--- a/common/Storyboarding/OsbAnimationWriter.cs
+++ b/common/Storyboarding/OsbAnimationWriter.cs
@@ -36,7 +36,7 @@ namespace StorybrewCommon.Storyboarding
             this.osbAnimation = osbAnimation;
         }
 
-        protected override OsbSprite CreateSprite(List<ICommand> segment)
+        protected override OsbSprite CreateSprite(List<IFragmentableCommand> segment)
         {
             if (osbAnimation.LoopType == OsbLoopType.LoopOnce && segment.Min(c => c.StartTime) >= osbAnimation.AnimationEndTime)
             {
@@ -89,9 +89,9 @@ namespace StorybrewCommon.Storyboarding
             else base.WriteHeader(sprite);          
         }
 
-        protected override HashSet<int> GetFragmentationTimes()
+        protected override HashSet<int> GetFragmentationTimes(IEnumerable<IFragmentableCommand> fragmentableCommands)
         {
-            var fragmentationTimes = base.GetFragmentationTimes();
+            var fragmentationTimes = base.GetFragmentationTimes(fragmentableCommands);
 
             var tMax = fragmentationTimes.Max();
             var nonFragmentableTimes = new HashSet<int>();

--- a/common/Storyboarding/OsbAnimationWriter.cs
+++ b/common/Storyboarding/OsbAnimationWriter.cs
@@ -13,7 +13,7 @@ namespace StorybrewCommon.Storyboarding
     public class OsbAnimationWriter : OsbSpriteWriter
 
     {
-        private OsbAnimation OsbAnimation;
+        private readonly OsbAnimation osbAnimation;
         public OsbAnimationWriter(OsbAnimation osbAnimation, AnimatedValue<CommandPosition> moveTimeline,
                                                              AnimatedValue<CommandDecimal> moveXTimeline,
                                                              AnimatedValue<CommandDecimal> moveYTimeline,
@@ -33,19 +33,19 @@ namespace StorybrewCommon.Storyboarding
                                                              colorTimeline,
                                                              writer, exportSettings, layer)
         {
-            OsbAnimation = osbAnimation;
+            this.osbAnimation = osbAnimation;
         }
 
         protected override OsbSprite CreateSprite(List<ICommand> segment)
         {
-            if (OsbAnimation.LoopType == OsbLoopType.LoopOnce && segment.Min(c => c.StartTime) >= OsbAnimation.AnimationEndTime)
+            if (osbAnimation.LoopType == OsbLoopType.LoopOnce && segment.Min(c => c.StartTime) >= osbAnimation.AnimationEndTime)
             {
                 //this shouldn't loop again so we need a sprite instead
                 var sprite = new OsbSprite()
                 {
-                    InitialPosition = OsbAnimation.InitialPosition,
-                    Origin = OsbAnimation.Origin,
-                    TexturePath = GetLastFramePath(),
+                    InitialPosition = osbAnimation.InitialPosition,
+                    Origin = osbAnimation.Origin,
+                    TexturePath = getLastFramePath(),
                 };
 
                 foreach (var command in segment)
@@ -57,12 +57,12 @@ namespace StorybrewCommon.Storyboarding
             {
                 var animation = new OsbAnimation()
                 {
-                    TexturePath = OsbAnimation.TexturePath,
-                    InitialPosition = OsbAnimation.InitialPosition,
-                    Origin = OsbAnimation.Origin,
-                    FrameCount = OsbAnimation.FrameCount,
-                    FrameDelay = OsbAnimation.FrameDelay,
-                    LoopType = OsbAnimation.LoopType,
+                    TexturePath = osbAnimation.TexturePath,
+                    InitialPosition = osbAnimation.InitialPosition,
+                    Origin = osbAnimation.Origin,
+                    FrameCount = osbAnimation.FrameCount,
+                    FrameDelay = osbAnimation.FrameDelay,
+                    LoopType = osbAnimation.LoopType,
                 };
 
                 foreach (var command in segment)
@@ -72,10 +72,10 @@ namespace StorybrewCommon.Storyboarding
             }
         }
 
-        private string GetLastFramePath()
+        private string getLastFramePath()
         {
-            var dir = Path.GetDirectoryName(OsbAnimation.TexturePath);
-            var file = string.Concat(Path.GetFileNameWithoutExtension(OsbAnimation.TexturePath), OsbAnimation.FrameCount - 1, Path.GetExtension(OsbAnimation.TexturePath));
+            var dir = Path.GetDirectoryName(osbAnimation.TexturePath);
+            var file = string.Concat(Path.GetFileNameWithoutExtension(osbAnimation.TexturePath), osbAnimation.FrameCount - 1, Path.GetExtension(osbAnimation.TexturePath));
             return Path.Combine(dir, file);
         }
 
@@ -83,8 +83,8 @@ namespace StorybrewCommon.Storyboarding
         {
             if (sprite is OsbAnimation animation)
             {
-                double frameDelay = animation.FrameDelay;
-                TextWriter.WriteLine($"Animation,{OsbLayer},{animation.Origin},\"{OsbSprite.TexturePath.Trim()}\",{animation.InitialPosition.X.ToString(ExportSettings.NumberFormat)},{animation.InitialPosition.Y.ToString(ExportSettings.NumberFormat)},{animation.FrameCount},{frameDelay.ToString(ExportSettings.NumberFormat)},{animation.LoopType}");
+                var frameDelay = animation.FrameDelay;
+                TextWriter.WriteLine($"Animation,{OsbLayer},{animation.Origin},\"{animation.TexturePath.Trim()}\",{animation.InitialPosition.X.ToString(ExportSettings.NumberFormat)},{animation.InitialPosition.Y.ToString(ExportSettings.NumberFormat)},{animation.FrameCount},{frameDelay.ToString(ExportSettings.NumberFormat)},{animation.LoopType}");
             }
             else
             {
@@ -94,14 +94,14 @@ namespace StorybrewCommon.Storyboarding
 
         protected override HashSet<int> GetFragmentationTimes()
         {
-            HashSet<int> fragmentationTimes = base.GetFragmentationTimes();
+            var fragmentationTimes = base.GetFragmentationTimes();
 
-            int tMax = fragmentationTimes.Max();
-            HashSet<int> nonFragmentableTimes = new HashSet<int>();
+            var tMax = fragmentationTimes.Max();
+            var nonFragmentableTimes = new HashSet<int>();
 
-            for (double d = OsbAnimation.StartTime; d < OsbAnimation.AnimationEndTime; d += OsbAnimation.LoopDuration)
+            for (double d = osbAnimation.StartTime; d < osbAnimation.AnimationEndTime; d += osbAnimation.LoopDuration)
             {
-                var range = Enumerable.Range((int)d + 1, (int)(OsbAnimation.LoopDuration - 1));
+                var range = Enumerable.Range((int)d + 1, (int)(osbAnimation.LoopDuration - 1));
                 nonFragmentableTimes.UnionWith(range);
             }
 

--- a/common/Storyboarding/OsbAnimationWriter.cs
+++ b/common/Storyboarding/OsbAnimationWriter.cs
@@ -37,7 +37,7 @@ namespace StorybrewCommon.Storyboarding
 
         protected override OsbSprite CreateSprite(List<ICommand> segment)
         {
-            if (OsbAnimation.LoopType == OsbLoopType.LoopOnce && segment.Min(c => c.StartTime) >= OsbAnimation.AnimationEndtime())
+            if (OsbAnimation.LoopType == OsbLoopType.LoopOnce && segment.Min(c => c.StartTime) >= OsbAnimation.AnimationEndTime)
             {
                 //this shouldn't loop again so we need a sprite instead
                 var sprite = new OsbSprite()
@@ -98,31 +98,15 @@ namespace StorybrewCommon.Storyboarding
             int tMax = fragmentationTimes.Max();
             HashSet<int> nonFragmentableTimes = new HashSet<int>();
 
-            for (double d = OsbAnimation.StartTime; d < OsbAnimation.AnimationEndtime(); d += OsbAnimation.LoopDuration())
+            for (double d = OsbAnimation.StartTime; d < OsbAnimation.AnimationEndTime; d += OsbAnimation.LoopDuration)
             {
-                var range = Enumerable.Range((int)d + 1, (int)(OsbAnimation.LoopDuration() - 1));
+                var range = Enumerable.Range((int)d + 1, (int)(OsbAnimation.LoopDuration - 1));
                 nonFragmentableTimes.UnionWith(range);
             }
 
             fragmentationTimes.RemoveWhere(t => nonFragmentableTimes.Contains(t) && t < tMax);
 
             return fragmentationTimes;
-        }
-    }
-
-    static class OsbAnimationExtensions
-    {
-        public static double AnimationEndtime(this OsbAnimation osbAnimation)
-        {
-            if (osbAnimation.LoopType == OsbLoopType.LoopOnce)
-                return osbAnimation.StartTime + osbAnimation.LoopDuration();
-            else
-                return osbAnimation.EndTime;
-        }
-
-        public static double LoopDuration(this OsbAnimation osbAnimation)
-        {
-            return osbAnimation.FrameCount * osbAnimation.FrameDelay;
         }
     }
 }

--- a/common/Storyboarding/OsbAnimationWriter.cs
+++ b/common/Storyboarding/OsbAnimationWriter.cs
@@ -1,0 +1,101 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using StorybrewCommon.Storyboarding.Commands;
+using StorybrewCommon.Storyboarding.CommandValues;
+using StorybrewCommon.Storyboarding.Display;
+
+namespace StorybrewCommon.Storyboarding
+{
+    class OsbAnimationWriter : OsbSpriteWriter
+    {
+        private OsbAnimation OsbAnimation;
+        public OsbAnimationWriter(OsbAnimation osbAnimation, AnimatedValue<CommandPosition> moveTimeline,
+                                                             AnimatedValue<CommandDecimal> moveXTimeline,
+                                                             AnimatedValue<CommandDecimal> moveYTimeline,
+                                                             AnimatedValue<CommandDecimal> scaleTimeline,
+                                                             AnimatedValue<CommandScale> scaleVecTimeline,
+                                                             AnimatedValue<CommandDecimal> rotateTimeline,
+                                                             AnimatedValue<CommandDecimal> fadeTimeline,
+                                                             AnimatedValue<CommandColor> colorTimeline,
+                                                             TextWriter writer, ExportSettings exportSettings, OsbLayer layer)
+                                        : base(osbAnimation, moveTimeline,
+                                                             moveXTimeline,
+                                                             moveYTimeline,
+                                                             scaleTimeline,
+                                                             scaleVecTimeline,
+                                                             rotateTimeline,
+                                                             fadeTimeline,
+                                                             colorTimeline,
+                                                             writer, exportSettings, layer)
+        {
+            OsbAnimation = osbAnimation;
+        }
+
+        protected override OsbSprite CreateSprite(List<ICommand> segment)
+        {
+            if (OsbAnimation.LoopType == OsbLoopType.LoopOnce && segment.Min(c => c.StartTime) >= OsbAnimation.AnimationEndtime())
+            {
+                //this shouldn't loop again so we need a sprite instead
+                return base.CreateSprite(segment);
+            }
+            else
+            {
+                var animation = new OsbAnimation()
+                {
+                    TexturePath = OsbAnimation.TexturePath,
+                    InitialPosition = OsbAnimation.InitialPosition,
+                    Origin = OsbAnimation.Origin,
+                    FrameCount = OsbAnimation.FrameCount,
+                    FrameDelay = OsbAnimation.FrameDelay,
+                    LoopType = OsbAnimation.LoopType,
+                };
+
+                foreach (var command in segment)
+                    animation.AddCommand(command);
+
+                return animation;
+            }
+        }
+
+        protected override void WriteHeader(OsbSprite sprite)
+        {
+            var animation = (OsbAnimation)sprite;
+            double frameDelay = animation.FrameDelay;
+            TextWriter.WriteLine($"Animation,{OsbLayer},{animation.Origin},\"{OsbSprite.TexturePath.Trim()}\",{animation.InitialPosition.X.ToString(ExportSettings.NumberFormat)},{animation.InitialPosition.Y.ToString(ExportSettings.NumberFormat)},{animation.FrameCount},{frameDelay.ToString(ExportSettings.NumberFormat)},{animation.LoopType}");
+        }
+
+        protected override HashSet<int> GetFragmentationTimes()
+        {
+            HashSet<int> fragmentationTimes = base.GetFragmentationTimes();
+
+            int tMax = fragmentationTimes.Max();
+
+            for (double d = OsbAnimation.StartTime; d < OsbAnimation.AnimationEndtime(); d += OsbAnimation.LoopDuration())
+            {
+                fragmentationTimes.RemoveWhere(t => t > d && t < d + OsbAnimation.LoopDuration() && t < tMax);
+            }
+
+            return fragmentationTimes;
+        }
+    }
+
+    static class OsbAnimationExtensions
+    {
+        public static double AnimationEndtime(this OsbAnimation osbAnimation)
+        {
+            if (osbAnimation.LoopType == OsbLoopType.LoopOnce)
+                return osbAnimation.StartTime + osbAnimation.LoopDuration();
+            else
+                return osbAnimation.EndTime;
+        }
+
+        public static double LoopDuration(this OsbAnimation osbAnimation)
+        {
+            return osbAnimation.FrameCount * osbAnimation.FrameDelay;
+        }
+    }
+}

--- a/common/Storyboarding/OsbAnimationWriter.cs
+++ b/common/Storyboarding/OsbAnimationWriter.cs
@@ -86,10 +86,7 @@ namespace StorybrewCommon.Storyboarding
                 var frameDelay = animation.FrameDelay;
                 TextWriter.WriteLine($"Animation,{OsbLayer},{animation.Origin},\"{animation.TexturePath.Trim()}\",{animation.InitialPosition.X.ToString(ExportSettings.NumberFormat)},{animation.InitialPosition.Y.ToString(ExportSettings.NumberFormat)},{animation.FrameCount},{frameDelay.ToString(ExportSettings.NumberFormat)},{animation.LoopType}");
             }
-            else
-            {
-                base.WriteHeader(sprite);
-            }           
+            else base.WriteHeader(sprite);          
         }
 
         protected override HashSet<int> GetFragmentationTimes()

--- a/common/Storyboarding/OsbAnimationWriter.cs
+++ b/common/Storyboarding/OsbAnimationWriter.cs
@@ -40,7 +40,17 @@ namespace StorybrewCommon.Storyboarding
             if (OsbAnimation.LoopType == OsbLoopType.LoopOnce && segment.Min(c => c.StartTime) >= OsbAnimation.AnimationEndtime())
             {
                 //this shouldn't loop again so we need a sprite instead
-                return base.CreateSprite(segment);
+                var sprite = new OsbSprite()
+                {
+                    InitialPosition = OsbAnimation.InitialPosition,
+                    Origin = OsbAnimation.Origin,
+                    TexturePath = GetLastFramePath(),
+                };
+
+                foreach (var command in segment)
+                    sprite.AddCommand(command);
+
+                return sprite;
             }
             else
             {
@@ -61,11 +71,24 @@ namespace StorybrewCommon.Storyboarding
             }
         }
 
+        private string GetLastFramePath()
+        {
+            var dir = Path.GetDirectoryName(OsbAnimation.TexturePath);
+            var file = string.Concat(Path.GetFileNameWithoutExtension(OsbAnimation.TexturePath), OsbAnimation.FrameCount - 1, Path.GetExtension(OsbAnimation.TexturePath));
+            return Path.Combine(dir, file);
+        }
+
         protected override void WriteHeader(OsbSprite sprite)
         {
-            var animation = (OsbAnimation)sprite;
-            double frameDelay = animation.FrameDelay;
-            TextWriter.WriteLine($"Animation,{OsbLayer},{animation.Origin},\"{OsbSprite.TexturePath.Trim()}\",{animation.InitialPosition.X.ToString(ExportSettings.NumberFormat)},{animation.InitialPosition.Y.ToString(ExportSettings.NumberFormat)},{animation.FrameCount},{frameDelay.ToString(ExportSettings.NumberFormat)},{animation.LoopType}");
+            if (sprite is OsbAnimation animation)
+            {
+                double frameDelay = animation.FrameDelay;
+                TextWriter.WriteLine($"Animation,{OsbLayer},{animation.Origin},\"{OsbSprite.TexturePath.Trim()}\",{animation.InitialPosition.X.ToString(ExportSettings.NumberFormat)},{animation.InitialPosition.Y.ToString(ExportSettings.NumberFormat)},{animation.FrameCount},{frameDelay.ToString(ExportSettings.NumberFormat)},{animation.LoopType}");
+            }
+            else
+            {
+                base.WriteHeader(sprite);
+            }           
         }
 
         protected override HashSet<int> GetFragmentationTimes()

--- a/common/Storyboarding/OsbSprite.cs
+++ b/common/Storyboarding/OsbSprite.cs
@@ -15,7 +15,7 @@ namespace StorybrewCommon.Storyboarding
         private List<ICommand> commands = new List<ICommand>();
         private CommandGroup currentCommandGroup;
 
-        public int MaxCommandCount = 300;
+        public int MaxCommandCount = 0;
 
         private string texturePath = "";
         public string TexturePath
@@ -307,6 +307,9 @@ namespace StorybrewCommon.Storyboarding
 
         public override void WriteOsb(TextWriter writer, ExportSettings exportSettings, OsbLayer layer)
         {
+            if (CommandCount == 0)
+                return;
+
             var osbSpriteWriter = new OsbSpriteWriter(this, MoveTimeline,
                                                             MoveXTimeline,
                                                             MoveYTimeline,

--- a/common/Storyboarding/OsbSprite.cs
+++ b/common/Storyboarding/OsbSprite.cs
@@ -230,6 +230,8 @@ namespace StorybrewCommon.Storyboarding
                     AddCommand(cmd);
                 EndGroup();
             }
+            else
+                throw new NotSupportedException($"Failed to add command: No support for adding command of type {command.GetType().FullName}");
         }
 
         #region Display 

--- a/common/Storyboarding/OsbSprite.cs
+++ b/common/Storyboarding/OsbSprite.cs
@@ -246,7 +246,7 @@ namespace StorybrewCommon.Storyboarding
         private AnimatedValue<CommandColor> colorTimeline = new AnimatedValue<CommandColor>(CommandColor.FromRgb(255, 255, 255));
         private AnimatedValue<CommandParameter> additiveTimeline = new AnimatedValue<CommandParameter>(CommandParameter.None, true);
         private AnimatedValue<CommandParameter> flipHTimeline = new AnimatedValue<CommandParameter>(CommandParameter.None, true);
-        private AnimatedValue<CommandParameter> FlipVTimeline = new AnimatedValue<CommandParameter>(CommandParameter.None, true);
+        private AnimatedValue<CommandParameter> flipVTimeline = new AnimatedValue<CommandParameter>(CommandParameter.None, true);
 
         public CommandPosition PositionAt(double time) => moveTimeline.HasCommands ? moveTimeline.ValueAtTime(time) : new CommandPosition(moveXTimeline.ValueAtTime(time), moveYTimeline.ValueAtTime(time));
         public CommandScale ScaleAt(double time) => scaleVecTimeline.HasCommands ? scaleVecTimeline.ValueAtTime(time) : new CommandScale(scaleTimeline.ValueAtTime(time));
@@ -255,7 +255,7 @@ namespace StorybrewCommon.Storyboarding
         public CommandColor ColorAt(double time) => colorTimeline.ValueAtTime(time);
         public CommandParameter AdditiveAt(double time) => additiveTimeline.ValueAtTime(time);
         public CommandParameter FlipHAt(double time) => flipHTimeline.ValueAtTime(time);
-        public CommandParameter FlipVAt(double time) => FlipVTimeline.ValueAtTime(time);
+        public CommandParameter FlipVAt(double time) => flipVTimeline.ValueAtTime(time);
 
         private void initializeDisplayValueBuilders()
         {
@@ -269,7 +269,7 @@ namespace StorybrewCommon.Storyboarding
             displayValueBuilders.Add(new KeyValuePair<Predicate<ICommand>, IAnimatedValueBuilder>((c) => c is ColorCommand, new AnimatedValueBuilder<CommandColor>(colorTimeline)));
             displayValueBuilders.Add(new KeyValuePair<Predicate<ICommand>, IAnimatedValueBuilder>((c) => (c as ParameterCommand)?.StartValue.Type == ParameterType.AdditiveBlending, new AnimatedValueBuilder<CommandParameter>(additiveTimeline)));
             displayValueBuilders.Add(new KeyValuePair<Predicate<ICommand>, IAnimatedValueBuilder>((c) => (c as ParameterCommand)?.StartValue.Type == ParameterType.FlipHorizontal, new AnimatedValueBuilder<CommandParameter>(flipHTimeline)));
-            displayValueBuilders.Add(new KeyValuePair<Predicate<ICommand>, IAnimatedValueBuilder>((c) => (c as ParameterCommand)?.StartValue.Type == ParameterType.FlipVertical, new AnimatedValueBuilder<CommandParameter>(FlipVTimeline)));
+            displayValueBuilders.Add(new KeyValuePair<Predicate<ICommand>, IAnimatedValueBuilder>((c) => (c as ParameterCommand)?.StartValue.Type == ParameterType.FlipVertical, new AnimatedValueBuilder<CommandParameter>(flipVTimeline)));
         }
 
         private void addDisplayCommand(ICommand command)

--- a/common/Storyboarding/OsbSprite.cs
+++ b/common/Storyboarding/OsbSprite.cs
@@ -41,9 +41,9 @@ namespace StorybrewCommon.Storyboarding
             {
                 if (initialPosition == value) return;
                 initialPosition = value;
-                moveTimeline.DefaultValue = initialPosition;
-                moveXTimeline.DefaultValue = initialPosition.X;
-                moveYTimeline.DefaultValue = initialPosition.Y;
+                MoveTimeline.DefaultValue = initialPosition;
+                MoveXTimeline.DefaultValue = initialPosition.X;
+                MoveYTimeline.DefaultValue = initialPosition.Y;
             }
         }
 
@@ -200,40 +200,40 @@ namespace StorybrewCommon.Storyboarding
 
         private List<KeyValuePair<Predicate<ICommand>, IAnimatedValueBuilder>> displayValueBuilders = new List<KeyValuePair<Predicate<ICommand>, IAnimatedValueBuilder>>();
 
-        protected AnimatedValue<CommandPosition> moveTimeline = new AnimatedValue<CommandPosition>();
-        protected AnimatedValue<CommandDecimal> moveXTimeline = new AnimatedValue<CommandDecimal>();
-        protected AnimatedValue<CommandDecimal> moveYTimeline = new AnimatedValue<CommandDecimal>();
-        protected AnimatedValue<CommandDecimal> scaleTimeline = new AnimatedValue<CommandDecimal>(1);
-        protected AnimatedValue<CommandScale> scaleVecTimeline = new AnimatedValue<CommandScale>(Vector2.One);
-        protected AnimatedValue<CommandDecimal> rotateTimeline = new AnimatedValue<CommandDecimal>();
-        protected AnimatedValue<CommandDecimal> fadeTimeline = new AnimatedValue<CommandDecimal>(1);
-        protected AnimatedValue<CommandColor> colorTimeline = new AnimatedValue<CommandColor>(CommandColor.FromRgb(255, 255, 255));
-        protected AnimatedValue<CommandParameter> additiveTimeline = new AnimatedValue<CommandParameter>(CommandParameter.None, true);
-        protected AnimatedValue<CommandParameter> flipHTimeline = new AnimatedValue<CommandParameter>(CommandParameter.None, true);
-        protected AnimatedValue<CommandParameter> flipVTimeline = new AnimatedValue<CommandParameter>(CommandParameter.None, true);
+        protected readonly AnimatedValue<CommandPosition> MoveTimeline = new AnimatedValue<CommandPosition>();
+        protected readonly AnimatedValue<CommandDecimal> MoveXTimeline = new AnimatedValue<CommandDecimal>();
+        protected readonly AnimatedValue<CommandDecimal> MoveYTimeline = new AnimatedValue<CommandDecimal>();
+        protected readonly AnimatedValue<CommandDecimal> ScaleTimeline = new AnimatedValue<CommandDecimal>(1);
+        protected readonly AnimatedValue<CommandScale> ScaleVecTimeline = new AnimatedValue<CommandScale>(Vector2.One);
+        protected readonly AnimatedValue<CommandDecimal> RotateTimeline = new AnimatedValue<CommandDecimal>();
+        protected readonly AnimatedValue<CommandDecimal> FadeTimeline = new AnimatedValue<CommandDecimal>(1);
+        protected readonly AnimatedValue<CommandColor> ColorTimeline = new AnimatedValue<CommandColor>(CommandColor.FromRgb(255, 255, 255));
+        protected readonly AnimatedValue<CommandParameter> AdditiveTimeline = new AnimatedValue<CommandParameter>(CommandParameter.None, true);
+        protected readonly AnimatedValue<CommandParameter> FlipHTimeline = new AnimatedValue<CommandParameter>(CommandParameter.None, true);
+        protected readonly AnimatedValue<CommandParameter> FlipVTimeline = new AnimatedValue<CommandParameter>(CommandParameter.None, true);
 
-        public CommandPosition PositionAt(double time) => moveTimeline.HasCommands ? moveTimeline.ValueAtTime(time) : new CommandPosition(moveXTimeline.ValueAtTime(time), moveYTimeline.ValueAtTime(time));
-        public CommandScale ScaleAt(double time) => scaleVecTimeline.HasCommands ? scaleVecTimeline.ValueAtTime(time) : new CommandScale(scaleTimeline.ValueAtTime(time));
-        public CommandDecimal RotationAt(double time) => rotateTimeline.ValueAtTime(time);
-        public CommandDecimal OpacityAt(double time) => fadeTimeline.ValueAtTime(time);
-        public CommandColor ColorAt(double time) => colorTimeline.ValueAtTime(time);
-        public CommandParameter AdditiveAt(double time) => additiveTimeline.ValueAtTime(time);
-        public CommandParameter FlipHAt(double time) => flipHTimeline.ValueAtTime(time);
-        public CommandParameter FlipVAt(double time) => flipVTimeline.ValueAtTime(time);
+        public CommandPosition PositionAt(double time) => MoveTimeline.HasCommands ? MoveTimeline.ValueAtTime(time) : new CommandPosition(MoveXTimeline.ValueAtTime(time), MoveYTimeline.ValueAtTime(time));
+        public CommandScale ScaleAt(double time) => ScaleVecTimeline.HasCommands ? ScaleVecTimeline.ValueAtTime(time) : new CommandScale(ScaleTimeline.ValueAtTime(time));
+        public CommandDecimal RotationAt(double time) => RotateTimeline.ValueAtTime(time);
+        public CommandDecimal OpacityAt(double time) => FadeTimeline.ValueAtTime(time);
+        public CommandColor ColorAt(double time) => ColorTimeline.ValueAtTime(time);
+        public CommandParameter AdditiveAt(double time) => AdditiveTimeline.ValueAtTime(time);
+        public CommandParameter FlipHAt(double time) => FlipHTimeline.ValueAtTime(time);
+        public CommandParameter FlipVAt(double time) => FlipVTimeline.ValueAtTime(time);
 
         private void initializeDisplayValueBuilders()
         {
-            displayValueBuilders.Add(new KeyValuePair<Predicate<ICommand>, IAnimatedValueBuilder>((c) => c is MoveCommand, new AnimatedValueBuilder<CommandPosition>(moveTimeline)));
-            displayValueBuilders.Add(new KeyValuePair<Predicate<ICommand>, IAnimatedValueBuilder>((c) => c is MoveXCommand, new AnimatedValueBuilder<CommandDecimal>(moveXTimeline)));
-            displayValueBuilders.Add(new KeyValuePair<Predicate<ICommand>, IAnimatedValueBuilder>((c) => c is MoveYCommand, new AnimatedValueBuilder<CommandDecimal>(moveYTimeline)));
-            displayValueBuilders.Add(new KeyValuePair<Predicate<ICommand>, IAnimatedValueBuilder>((c) => c is ScaleCommand, new AnimatedValueBuilder<CommandDecimal>(scaleTimeline)));
-            displayValueBuilders.Add(new KeyValuePair<Predicate<ICommand>, IAnimatedValueBuilder>((c) => c is VScaleCommand, new AnimatedValueBuilder<CommandScale>(scaleVecTimeline)));
-            displayValueBuilders.Add(new KeyValuePair<Predicate<ICommand>, IAnimatedValueBuilder>((c) => c is RotateCommand, new AnimatedValueBuilder<CommandDecimal>(rotateTimeline)));
-            displayValueBuilders.Add(new KeyValuePair<Predicate<ICommand>, IAnimatedValueBuilder>((c) => c is FadeCommand, new AnimatedValueBuilder<CommandDecimal>(fadeTimeline)));
-            displayValueBuilders.Add(new KeyValuePair<Predicate<ICommand>, IAnimatedValueBuilder>((c) => c is ColorCommand, new AnimatedValueBuilder<CommandColor>(colorTimeline)));
-            displayValueBuilders.Add(new KeyValuePair<Predicate<ICommand>, IAnimatedValueBuilder>((c) => (c as ParameterCommand)?.StartValue.Type == ParameterType.AdditiveBlending, new AnimatedValueBuilder<CommandParameter>(additiveTimeline)));
-            displayValueBuilders.Add(new KeyValuePair<Predicate<ICommand>, IAnimatedValueBuilder>((c) => (c as ParameterCommand)?.StartValue.Type == ParameterType.FlipHorizontal, new AnimatedValueBuilder<CommandParameter>(flipHTimeline)));
-            displayValueBuilders.Add(new KeyValuePair<Predicate<ICommand>, IAnimatedValueBuilder>((c) => (c as ParameterCommand)?.StartValue.Type == ParameterType.FlipVertical, new AnimatedValueBuilder<CommandParameter>(flipVTimeline)));
+            displayValueBuilders.Add(new KeyValuePair<Predicate<ICommand>, IAnimatedValueBuilder>((c) => c is MoveCommand, new AnimatedValueBuilder<CommandPosition>(MoveTimeline)));
+            displayValueBuilders.Add(new KeyValuePair<Predicate<ICommand>, IAnimatedValueBuilder>((c) => c is MoveXCommand, new AnimatedValueBuilder<CommandDecimal>(MoveXTimeline)));
+            displayValueBuilders.Add(new KeyValuePair<Predicate<ICommand>, IAnimatedValueBuilder>((c) => c is MoveYCommand, new AnimatedValueBuilder<CommandDecimal>(MoveYTimeline)));
+            displayValueBuilders.Add(new KeyValuePair<Predicate<ICommand>, IAnimatedValueBuilder>((c) => c is ScaleCommand, new AnimatedValueBuilder<CommandDecimal>(ScaleTimeline)));
+            displayValueBuilders.Add(new KeyValuePair<Predicate<ICommand>, IAnimatedValueBuilder>((c) => c is VScaleCommand, new AnimatedValueBuilder<CommandScale>(ScaleVecTimeline)));
+            displayValueBuilders.Add(new KeyValuePair<Predicate<ICommand>, IAnimatedValueBuilder>((c) => c is RotateCommand, new AnimatedValueBuilder<CommandDecimal>(RotateTimeline)));
+            displayValueBuilders.Add(new KeyValuePair<Predicate<ICommand>, IAnimatedValueBuilder>((c) => c is FadeCommand, new AnimatedValueBuilder<CommandDecimal>(FadeTimeline)));
+            displayValueBuilders.Add(new KeyValuePair<Predicate<ICommand>, IAnimatedValueBuilder>((c) => c is ColorCommand, new AnimatedValueBuilder<CommandColor>(ColorTimeline)));
+            displayValueBuilders.Add(new KeyValuePair<Predicate<ICommand>, IAnimatedValueBuilder>((c) => (c as ParameterCommand)?.StartValue.Type == ParameterType.AdditiveBlending, new AnimatedValueBuilder<CommandParameter>(AdditiveTimeline)));
+            displayValueBuilders.Add(new KeyValuePair<Predicate<ICommand>, IAnimatedValueBuilder>((c) => (c as ParameterCommand)?.StartValue.Type == ParameterType.FlipHorizontal, new AnimatedValueBuilder<CommandParameter>(FlipHTimeline)));
+            displayValueBuilders.Add(new KeyValuePair<Predicate<ICommand>, IAnimatedValueBuilder>((c) => (c as ParameterCommand)?.StartValue.Type == ParameterType.FlipVertical, new AnimatedValueBuilder<CommandParameter>(FlipVTimeline)));
         }
 
         private void addDisplayCommand(ICommand command)
@@ -271,15 +271,15 @@ namespace StorybrewCommon.Storyboarding
 
         public override void WriteOsb(TextWriter writer, ExportSettings exportSettings, OsbLayer layer)
         {
-            OsbSpriteWriter osbSpriteWriter = new OsbSpriteWriter(this, moveTimeline,
-                                                                        moveXTimeline,
-                                                                        moveYTimeline,
-                                                                        scaleTimeline,
-                                                                        scaleVecTimeline,
-                                                                        rotateTimeline,
-                                                                        fadeTimeline,
-                                                                        colorTimeline,
-                                                                        writer, exportSettings, layer);
+            var osbSpriteWriter = new OsbSpriteWriter(this, MoveTimeline,
+                                                            MoveXTimeline,
+                                                            MoveYTimeline,
+                                                            ScaleTimeline,
+                                                            ScaleVecTimeline,
+                                                            RotateTimeline,
+                                                            FadeTimeline,
+                                                            ColorTimeline,
+                                                            writer, exportSettings, layer);
             osbSpriteWriter.WriteOsb();
         }
     }

--- a/common/Storyboarding/OsbSprite.cs
+++ b/common/Storyboarding/OsbSprite.cs
@@ -196,6 +196,42 @@ namespace StorybrewCommon.Storyboarding
             clearStartEndTimes();
         }
 
+        public void AddCommand(ICommand command)
+        {
+            if (command is ColorCommand colorCommand)
+                Color(colorCommand.Easing, colorCommand.StartTime, colorCommand.EndTime, colorCommand.StartValue, colorCommand.EndValue);
+            else if (command is FadeCommand fadeCommand)
+                Fade(fadeCommand.Easing, fadeCommand.StartTime, fadeCommand.EndTime, fadeCommand.StartValue, fadeCommand.EndValue);
+            else if (command is ScaleCommand scaleCommand)
+                Scale(scaleCommand.Easing, scaleCommand.StartTime, scaleCommand.EndTime, scaleCommand.StartValue, scaleCommand.EndValue);
+            else if (command is VScaleCommand vScaleCommand)
+                ScaleVec(vScaleCommand.Easing, vScaleCommand.StartTime, vScaleCommand.EndTime, vScaleCommand.StartValue, vScaleCommand.EndValue);
+            else if (command is ParameterCommand parameterCommand)
+                Parameter(parameterCommand.Easing, parameterCommand.StartTime, parameterCommand.EndTime, parameterCommand.StartValue);
+            else if (command is MoveCommand moveCommand)
+                Move(moveCommand.Easing, moveCommand.StartTime, moveCommand.EndTime, moveCommand.StartValue, moveCommand.EndValue);
+            else if (command is MoveXCommand moveXCommand)
+                MoveX(moveXCommand.Easing, moveXCommand.StartTime, moveXCommand.EndTime, moveXCommand.StartValue, moveXCommand.EndValue);
+            else if (command is MoveYCommand moveYCommand)
+                MoveY(moveYCommand.Easing, moveYCommand.StartTime, moveYCommand.EndTime, moveYCommand.StartValue, moveYCommand.EndValue);
+            else if (command is RotateCommand rotateCommand)
+                Rotate(rotateCommand.Easing, rotateCommand.StartTime, rotateCommand.EndTime, rotateCommand.StartValue, rotateCommand.EndValue);
+            else if (command is LoopCommand loopCommand)
+            {
+                StartLoopGroup(loopCommand.StartTime, loopCommand.LoopCount);
+                foreach (var cmd in loopCommand.Commands)
+                    AddCommand(cmd);
+                EndGroup();
+            }
+            else if (command is TriggerCommand triggerCommand)
+            {
+                StartTriggerGroup(triggerCommand.TriggerName, triggerCommand.StartTime, triggerCommand.EndTime, triggerCommand.Group);
+                foreach (var cmd in triggerCommand.Commands)
+                    AddCommand(cmd);
+                EndGroup();
+            }
+        }
+
         #region Display 
 
         private List<KeyValuePair<Predicate<ICommand>, IAnimatedValueBuilder>> displayValueBuilders = new List<KeyValuePair<Predicate<ICommand>, IAnimatedValueBuilder>>();

--- a/common/Storyboarding/OsbSprite.cs
+++ b/common/Storyboarding/OsbSprite.cs
@@ -41,9 +41,9 @@ namespace StorybrewCommon.Storyboarding
             {
                 if (initialPosition == value) return;
                 initialPosition = value;
-                MoveTimeline.DefaultValue = initialPosition;
-                MoveXTimeline.DefaultValue = initialPosition.X;
-                MoveYTimeline.DefaultValue = initialPosition.Y;
+                moveTimeline.DefaultValue = initialPosition;
+                moveXTimeline.DefaultValue = initialPosition.X;
+                moveYTimeline.DefaultValue = initialPosition.Y;
             }
         }
 
@@ -236,39 +236,39 @@ namespace StorybrewCommon.Storyboarding
 
         private List<KeyValuePair<Predicate<ICommand>, IAnimatedValueBuilder>> displayValueBuilders = new List<KeyValuePair<Predicate<ICommand>, IAnimatedValueBuilder>>();
 
-        protected readonly AnimatedValue<CommandPosition> MoveTimeline = new AnimatedValue<CommandPosition>();
-        protected readonly AnimatedValue<CommandDecimal> MoveXTimeline = new AnimatedValue<CommandDecimal>();
-        protected readonly AnimatedValue<CommandDecimal> MoveYTimeline = new AnimatedValue<CommandDecimal>();
-        protected readonly AnimatedValue<CommandDecimal> ScaleTimeline = new AnimatedValue<CommandDecimal>(1);
-        protected readonly AnimatedValue<CommandScale> ScaleVecTimeline = new AnimatedValue<CommandScale>(Vector2.One);
-        protected readonly AnimatedValue<CommandDecimal> RotateTimeline = new AnimatedValue<CommandDecimal>();
-        protected readonly AnimatedValue<CommandDecimal> FadeTimeline = new AnimatedValue<CommandDecimal>(1);
-        protected readonly AnimatedValue<CommandColor> ColorTimeline = new AnimatedValue<CommandColor>(CommandColor.FromRgb(255, 255, 255));
-        protected readonly AnimatedValue<CommandParameter> AdditiveTimeline = new AnimatedValue<CommandParameter>(CommandParameter.None, true);
-        protected readonly AnimatedValue<CommandParameter> FlipHTimeline = new AnimatedValue<CommandParameter>(CommandParameter.None, true);
-        protected readonly AnimatedValue<CommandParameter> FlipVTimeline = new AnimatedValue<CommandParameter>(CommandParameter.None, true);
+        private AnimatedValue<CommandPosition> moveTimeline = new AnimatedValue<CommandPosition>();
+        private AnimatedValue<CommandDecimal> moveXTimeline = new AnimatedValue<CommandDecimal>();
+        private AnimatedValue<CommandDecimal> moveYTimeline = new AnimatedValue<CommandDecimal>();
+        private AnimatedValue<CommandDecimal> scaleTimeline = new AnimatedValue<CommandDecimal>(1);
+        private AnimatedValue<CommandScale> scaleVecTimeline = new AnimatedValue<CommandScale>(Vector2.One);
+        private AnimatedValue<CommandDecimal> rotateTimeline = new AnimatedValue<CommandDecimal>();
+        private AnimatedValue<CommandDecimal> fadeTimeline = new AnimatedValue<CommandDecimal>(1);
+        private AnimatedValue<CommandColor> colorTimeline = new AnimatedValue<CommandColor>(CommandColor.FromRgb(255, 255, 255));
+        private AnimatedValue<CommandParameter> additiveTimeline = new AnimatedValue<CommandParameter>(CommandParameter.None, true);
+        private AnimatedValue<CommandParameter> flipHTimeline = new AnimatedValue<CommandParameter>(CommandParameter.None, true);
+        private AnimatedValue<CommandParameter> FlipVTimeline = new AnimatedValue<CommandParameter>(CommandParameter.None, true);
 
-        public CommandPosition PositionAt(double time) => MoveTimeline.HasCommands ? MoveTimeline.ValueAtTime(time) : new CommandPosition(MoveXTimeline.ValueAtTime(time), MoveYTimeline.ValueAtTime(time));
-        public CommandScale ScaleAt(double time) => ScaleVecTimeline.HasCommands ? ScaleVecTimeline.ValueAtTime(time) : new CommandScale(ScaleTimeline.ValueAtTime(time));
-        public CommandDecimal RotationAt(double time) => RotateTimeline.ValueAtTime(time);
-        public CommandDecimal OpacityAt(double time) => FadeTimeline.ValueAtTime(time);
-        public CommandColor ColorAt(double time) => ColorTimeline.ValueAtTime(time);
-        public CommandParameter AdditiveAt(double time) => AdditiveTimeline.ValueAtTime(time);
-        public CommandParameter FlipHAt(double time) => FlipHTimeline.ValueAtTime(time);
+        public CommandPosition PositionAt(double time) => moveTimeline.HasCommands ? moveTimeline.ValueAtTime(time) : new CommandPosition(moveXTimeline.ValueAtTime(time), moveYTimeline.ValueAtTime(time));
+        public CommandScale ScaleAt(double time) => scaleVecTimeline.HasCommands ? scaleVecTimeline.ValueAtTime(time) : new CommandScale(scaleTimeline.ValueAtTime(time));
+        public CommandDecimal RotationAt(double time) => rotateTimeline.ValueAtTime(time);
+        public CommandDecimal OpacityAt(double time) => fadeTimeline.ValueAtTime(time);
+        public CommandColor ColorAt(double time) => colorTimeline.ValueAtTime(time);
+        public CommandParameter AdditiveAt(double time) => additiveTimeline.ValueAtTime(time);
+        public CommandParameter FlipHAt(double time) => flipHTimeline.ValueAtTime(time);
         public CommandParameter FlipVAt(double time) => FlipVTimeline.ValueAtTime(time);
 
         private void initializeDisplayValueBuilders()
         {
-            displayValueBuilders.Add(new KeyValuePair<Predicate<ICommand>, IAnimatedValueBuilder>((c) => c is MoveCommand, new AnimatedValueBuilder<CommandPosition>(MoveTimeline)));
-            displayValueBuilders.Add(new KeyValuePair<Predicate<ICommand>, IAnimatedValueBuilder>((c) => c is MoveXCommand, new AnimatedValueBuilder<CommandDecimal>(MoveXTimeline)));
-            displayValueBuilders.Add(new KeyValuePair<Predicate<ICommand>, IAnimatedValueBuilder>((c) => c is MoveYCommand, new AnimatedValueBuilder<CommandDecimal>(MoveYTimeline)));
-            displayValueBuilders.Add(new KeyValuePair<Predicate<ICommand>, IAnimatedValueBuilder>((c) => c is ScaleCommand, new AnimatedValueBuilder<CommandDecimal>(ScaleTimeline)));
-            displayValueBuilders.Add(new KeyValuePair<Predicate<ICommand>, IAnimatedValueBuilder>((c) => c is VScaleCommand, new AnimatedValueBuilder<CommandScale>(ScaleVecTimeline)));
-            displayValueBuilders.Add(new KeyValuePair<Predicate<ICommand>, IAnimatedValueBuilder>((c) => c is RotateCommand, new AnimatedValueBuilder<CommandDecimal>(RotateTimeline)));
-            displayValueBuilders.Add(new KeyValuePair<Predicate<ICommand>, IAnimatedValueBuilder>((c) => c is FadeCommand, new AnimatedValueBuilder<CommandDecimal>(FadeTimeline)));
-            displayValueBuilders.Add(new KeyValuePair<Predicate<ICommand>, IAnimatedValueBuilder>((c) => c is ColorCommand, new AnimatedValueBuilder<CommandColor>(ColorTimeline)));
-            displayValueBuilders.Add(new KeyValuePair<Predicate<ICommand>, IAnimatedValueBuilder>((c) => (c as ParameterCommand)?.StartValue.Type == ParameterType.AdditiveBlending, new AnimatedValueBuilder<CommandParameter>(AdditiveTimeline)));
-            displayValueBuilders.Add(new KeyValuePair<Predicate<ICommand>, IAnimatedValueBuilder>((c) => (c as ParameterCommand)?.StartValue.Type == ParameterType.FlipHorizontal, new AnimatedValueBuilder<CommandParameter>(FlipHTimeline)));
+            displayValueBuilders.Add(new KeyValuePair<Predicate<ICommand>, IAnimatedValueBuilder>((c) => c is MoveCommand, new AnimatedValueBuilder<CommandPosition>(moveTimeline)));
+            displayValueBuilders.Add(new KeyValuePair<Predicate<ICommand>, IAnimatedValueBuilder>((c) => c is MoveXCommand, new AnimatedValueBuilder<CommandDecimal>(moveXTimeline)));
+            displayValueBuilders.Add(new KeyValuePair<Predicate<ICommand>, IAnimatedValueBuilder>((c) => c is MoveYCommand, new AnimatedValueBuilder<CommandDecimal>(moveYTimeline)));
+            displayValueBuilders.Add(new KeyValuePair<Predicate<ICommand>, IAnimatedValueBuilder>((c) => c is ScaleCommand, new AnimatedValueBuilder<CommandDecimal>(scaleTimeline)));
+            displayValueBuilders.Add(new KeyValuePair<Predicate<ICommand>, IAnimatedValueBuilder>((c) => c is VScaleCommand, new AnimatedValueBuilder<CommandScale>(scaleVecTimeline)));
+            displayValueBuilders.Add(new KeyValuePair<Predicate<ICommand>, IAnimatedValueBuilder>((c) => c is RotateCommand, new AnimatedValueBuilder<CommandDecimal>(rotateTimeline)));
+            displayValueBuilders.Add(new KeyValuePair<Predicate<ICommand>, IAnimatedValueBuilder>((c) => c is FadeCommand, new AnimatedValueBuilder<CommandDecimal>(fadeTimeline)));
+            displayValueBuilders.Add(new KeyValuePair<Predicate<ICommand>, IAnimatedValueBuilder>((c) => c is ColorCommand, new AnimatedValueBuilder<CommandColor>(colorTimeline)));
+            displayValueBuilders.Add(new KeyValuePair<Predicate<ICommand>, IAnimatedValueBuilder>((c) => (c as ParameterCommand)?.StartValue.Type == ParameterType.AdditiveBlending, new AnimatedValueBuilder<CommandParameter>(additiveTimeline)));
+            displayValueBuilders.Add(new KeyValuePair<Predicate<ICommand>, IAnimatedValueBuilder>((c) => (c as ParameterCommand)?.StartValue.Type == ParameterType.FlipHorizontal, new AnimatedValueBuilder<CommandParameter>(flipHTimeline)));
             displayValueBuilders.Add(new KeyValuePair<Predicate<ICommand>, IAnimatedValueBuilder>((c) => (c as ParameterCommand)?.StartValue.Type == ParameterType.FlipVertical, new AnimatedValueBuilder<CommandParameter>(FlipVTimeline)));
         }
 
@@ -310,15 +310,15 @@ namespace StorybrewCommon.Storyboarding
             if (CommandCount == 0)
                 return;
 
-            var osbSpriteWriter = new OsbSpriteWriter(this, MoveTimeline,
-                                                            MoveXTimeline,
-                                                            MoveYTimeline,
-                                                            ScaleTimeline,
-                                                            ScaleVecTimeline,
-                                                            RotateTimeline,
-                                                            FadeTimeline,
-                                                            ColorTimeline,
-                                                            writer, exportSettings, layer);
+            var osbSpriteWriter = OsbWriterFactory.CreateWriter(this, moveTimeline,
+                                                                      moveXTimeline,
+                                                                      moveYTimeline,
+                                                                      scaleTimeline,
+                                                                      scaleVecTimeline,
+                                                                      rotateTimeline,
+                                                                      fadeTimeline,
+                                                                      colorTimeline,
+                                                                      writer, exportSettings, layer);
             osbSpriteWriter.WriteOsb();
         }
     }

--- a/common/Storyboarding/OsbSpriteWriter.cs
+++ b/common/Storyboarding/OsbSpriteWriter.cs
@@ -1,0 +1,302 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using StorybrewCommon.Storyboarding.Commands;
+using StorybrewCommon.Storyboarding.CommandValues;
+using StorybrewCommon.Storyboarding.Display;
+
+namespace StorybrewCommon.Storyboarding
+{
+    class OsbSpriteWriter
+    {
+        protected OsbSprite OsbSprite;
+        AnimatedValue<CommandPosition> moveTimeline;
+        AnimatedValue<CommandDecimal> moveXTimeline;
+        AnimatedValue<CommandDecimal> moveYTimeline;
+        AnimatedValue<CommandDecimal> scaleTimeline;
+        AnimatedValue<CommandScale> scaleVecTimeline;
+        AnimatedValue<CommandDecimal> rotateTimeline;
+        AnimatedValue<CommandDecimal> fadeTimeline;
+        AnimatedValue<CommandColor> colorTimeline;
+        protected TextWriter TextWriter;
+        protected ExportSettings ExportSettings;
+        protected OsbLayer OsbLayer;
+
+        public OsbSpriteWriter(OsbSprite osbSprite, AnimatedValue<CommandPosition> moveTimeline,
+                                                    AnimatedValue<CommandDecimal> moveXTimeline,
+                                                    AnimatedValue<CommandDecimal> moveYTimeline,
+                                                    AnimatedValue<CommandDecimal> scaleTimeline,
+                                                    AnimatedValue<CommandScale> scaleVecTimeline,
+                                                    AnimatedValue<CommandDecimal> rotateTimeline,
+                                                    AnimatedValue<CommandDecimal> fadeTimeline,
+                                                    AnimatedValue<CommandColor> colorTimeline, 
+                                                    TextWriter writer, ExportSettings exportSettings, OsbLayer layer)
+        {
+            OsbSprite = osbSprite;
+            this.moveTimeline = moveTimeline;
+            this.moveXTimeline = moveXTimeline;
+            this.moveYTimeline = moveYTimeline;
+            this.scaleTimeline = scaleTimeline;
+            this.scaleVecTimeline = scaleVecTimeline;
+            this.rotateTimeline = rotateTimeline;
+            this.fadeTimeline = fadeTimeline;
+            this.colorTimeline = colorTimeline;
+            TextWriter = writer;
+            ExportSettings = exportSettings;
+            OsbLayer = layer;
+        }
+
+        public void WriteOsb()
+        {
+            if (OsbSprite.CommandCount == 0)
+                return;
+
+            if (OsbSprite.CommandCount > OsbSprite.MaxCommandCount && IsFragmentable())
+            {
+                HashSet<int> fragmentationTimes = GetFragmentationTimes();
+
+                List<ICommand> commands = OsbSprite.Commands.ToList();
+
+                while (commands.Count > 0)
+                {
+                    var segment = GetNextSegment(fragmentationTimes, commands);
+                    var sprite = CreateSprite(segment);                       
+                    WriteOsbSprite(sprite);
+                }
+            }
+            else
+            {
+                WriteOsbSprite(OsbSprite);
+            }
+        }
+
+        protected virtual OsbSprite CreateSprite(List<ICommand> segment)
+        {
+            var sprite = new OsbSprite()
+            {
+                TexturePath = OsbSprite.TexturePath,
+                InitialPosition = OsbSprite.InitialPosition,
+                Origin = OsbSprite.Origin,
+            };
+
+            foreach (var command in segment)
+                sprite.AddCommand(command);
+
+            return sprite;
+        }
+
+        private void WriteOsbSprite(OsbSprite sprite)
+        {
+            WriteHeader(sprite);
+            foreach (var command in sprite.Commands)
+                command.WriteOsb(TextWriter, ExportSettings, 1);
+        }
+
+        protected virtual void WriteHeader(OsbSprite sprite)
+        {
+            TextWriter.Write($"Sprite,{OsbLayer},{sprite.Origin},\"{sprite.TexturePath.Trim()}\"");
+            if (!moveTimeline.HasCommands && !moveXTimeline.HasCommands)
+                TextWriter.Write($",{sprite.InitialPosition.X.ToString(ExportSettings.NumberFormat)}");
+            else TextWriter.Write($",0");
+            if (!moveTimeline.HasCommands && !moveYTimeline.HasCommands)
+                TextWriter.WriteLine($",{sprite.InitialPosition.Y.ToString(ExportSettings.NumberFormat)}");
+            else TextWriter.WriteLine($",0");
+        }
+
+        protected virtual bool IsFragmentable()
+        {
+            if (OsbSprite.CommandCount < OsbSprite.MaxCommandCount)
+                return false;
+
+            return !(moveTimeline.HasOverlap ||
+                     moveXTimeline.HasOverlap ||
+                     moveYTimeline.HasOverlap ||
+                     rotateTimeline.HasOverlap ||
+                     scaleTimeline.HasOverlap ||
+                     scaleVecTimeline.HasOverlap ||
+                     fadeTimeline.HasOverlap ||
+                     colorTimeline.HasOverlap);
+        }
+
+        protected virtual HashSet<int> GetFragmentationTimes()
+        {
+            HashSet<int> fragmentationTimes = new HashSet<int>();
+            var nonFragmentableCommands = OsbSprite.Commands.Where(c => !c.IsFragmentable()).ToList();
+
+            fragmentationTimes.UnionWith(Enumerable.Range((int)OsbSprite.Commands.Min(c => c.StartTime), (int)OsbSprite.Commands.Max(c => c.EndTime)));
+            //Performance seems not so fresh here (e.g. when using an Easing for the spectrum commands)
+            nonFragmentableCommands.ForEach(c => fragmentationTimes.RemoveWhere(t => t > c.StartTime && t < c.EndTime));
+
+            return fragmentationTimes;
+        }
+
+        private List<ICommand> GetNextSegment(HashSet<int> fragmentationTimes, List<ICommand> commands)
+        {
+            List<ICommand> segment = new List<ICommand>();
+
+            int startTime = fragmentationTimes.Min();
+            int endTime;
+            int maxCommandCount = OsbSprite.MaxCommandCount;
+
+            //split the last 2 segments evenly so we don't have weird 5 command leftovers
+            if (commands.Count < OsbSprite.MaxCommandCount * 2 && commands.Count > OsbSprite.MaxCommandCount)
+                maxCommandCount = (int)Math.Ceiling(commands.Count / 2.0);
+
+            if (commands.Count < maxCommandCount)
+                endTime = fragmentationTimes.Max() + 1;
+            else
+            {
+                var cEndTime = (int)commands.OrderBy(c => c.StartTime).ElementAt(maxCommandCount - 1).StartTime;
+                if (fragmentationTimes.Contains(cEndTime))
+                    endTime = cEndTime;
+                else
+                {
+                    endTime = fragmentationTimes.Where(t => t < cEndTime).Max();
+                    if (endTime == startTime) // segment can't be <= MaxCommandCount, so we use the smallest available
+                        endTime = fragmentationTimes.First(t => t > startTime);
+                }
+            }
+
+            foreach (var cmd in commands.Where(c => c.StartTime < endTime))
+            {
+                var sTime = Math.Max(startTime, (int)Math.Round(cmd.StartTime));
+                var eTime = Math.Min(endTime, (int)Math.Round(cmd.EndTime));
+                ICommand command;
+                if (sTime == (int)Math.Round(cmd.StartTime) && eTime == (int)Math.Round(cmd.EndTime))
+                {
+                    command = cmd;
+                }
+                else
+                {
+                    var type = cmd.GetType();
+                    var easingProp = type.GetProperty("Easing");
+                    var valueAtMethod = type.GetMethod("ValueAtTime");
+                    var startValue = valueAtMethod.Invoke(cmd, new object[] { sTime });
+                    var endValue = valueAtMethod.Invoke(cmd, new object[] { eTime });
+                    var easing = easingProp.GetValue(cmd);
+
+                    if (!(cmd is ParameterCommand))
+                        command = (ICommand)Activator.CreateInstance(type, new object[] { easing, sTime, eTime, startValue, endValue });
+                    else
+                        command = (ICommand)Activator.CreateInstance(type, new object[] { easing, sTime, eTime, startValue });
+                }
+
+                segment.Add(command);
+            }
+
+            AddStaticCommands(segment, startTime);
+
+            fragmentationTimes.RemoveWhere(t => t < endTime);
+            commands.RemoveAll(c => c.EndTime <= endTime);
+
+            return segment;
+        }
+
+        private void AddStaticCommands(List<ICommand> segment, int startTime)
+        {
+            if (moveTimeline.HasCommands && !segment.Any(c => c is MoveCommand && c.StartTime == startTime))
+            {
+                var value = moveTimeline.ValueAtTime(startTime);
+                segment.Add(new MoveCommand(OsbEasing.None, startTime, startTime, value, value));
+            }
+
+            if (moveXTimeline.HasCommands && !segment.Any(c => c is MoveXCommand && c.StartTime == startTime))
+            {
+                var value = moveXTimeline.ValueAtTime(startTime);
+                segment.Add(new MoveXCommand(OsbEasing.None, startTime, startTime, value, value));
+            }
+
+            if (moveYTimeline.HasCommands && !segment.Any(c => c is MoveYCommand && c.StartTime == startTime))
+            {
+                var value = moveYTimeline.ValueAtTime(startTime);
+                segment.Add(new MoveYCommand(OsbEasing.None, startTime, startTime, value, value));
+            }
+
+            if (rotateTimeline.HasCommands && !segment.Any(c => c is RotateCommand && c.StartTime == startTime))
+            {
+                var value = rotateTimeline.ValueAtTime(startTime);
+                segment.Add(new RotateCommand(OsbEasing.None, startTime, startTime, value, value));
+            }
+
+            if (scaleTimeline.HasCommands && !segment.Any(c => c is ScaleCommand && c.StartTime == startTime))
+            {
+                var value = scaleTimeline.ValueAtTime(startTime);
+                segment.Add(new ScaleCommand(OsbEasing.None, startTime, startTime, value, value));
+            }
+
+            if (scaleVecTimeline.HasCommands && !segment.Any(c => c is VScaleCommand && c.StartTime == startTime))
+            {
+                var value = scaleVecTimeline.ValueAtTime(startTime);
+                segment.Add(new VScaleCommand(OsbEasing.None, startTime, startTime, value, value));
+            }
+
+            if (colorTimeline.HasCommands && !segment.Any(c => c is ColorCommand && c.StartTime == startTime))
+            {
+                var value = colorTimeline.ValueAtTime(startTime);
+                segment.Add(new ColorCommand(OsbEasing.None, startTime, startTime, value, value));
+            }
+
+            if (fadeTimeline.HasCommands && !segment.Any(c => c is FadeCommand && c.StartTime == startTime))
+            {
+                var value = fadeTimeline.ValueAtTime(startTime);
+                segment.Add(new FadeCommand(OsbEasing.None, startTime, startTime, value, value));
+            }
+        } 
+    }
+
+    static class OsbSpriteExtensions
+    {
+        public static void AddCommand(this OsbSprite sprite, ICommand command)
+        {
+            if (command is ColorCommand colorCommand)
+                sprite.Color(colorCommand.Easing, colorCommand.StartTime, colorCommand.EndTime, colorCommand.StartValue, colorCommand.EndValue);
+            else if (command is FadeCommand fadeCommand)
+                sprite.Fade(fadeCommand.Easing, fadeCommand.StartTime, fadeCommand.EndTime, fadeCommand.StartValue, fadeCommand.EndValue);
+            else if (command is ScaleCommand scaleCommand)
+                sprite.Scale(scaleCommand.Easing, scaleCommand.StartTime, scaleCommand.EndTime, scaleCommand.StartValue, scaleCommand.EndValue);
+            else if (command is VScaleCommand vScaleCommand)
+                sprite.ScaleVec(vScaleCommand.Easing, vScaleCommand.StartTime, vScaleCommand.EndTime, vScaleCommand.StartValue, vScaleCommand.EndValue);
+            else if (command is ParameterCommand parameterCommand)
+                sprite.Parameter(parameterCommand.Easing, parameterCommand.StartTime, parameterCommand.EndTime, parameterCommand.StartValue);
+            else if (command is MoveCommand moveCommand)
+                sprite.Move(moveCommand.Easing, moveCommand.StartTime, moveCommand.EndTime, moveCommand.StartValue, moveCommand.EndValue);
+            else if (command is MoveXCommand moveXCommand)
+                sprite.MoveX(moveXCommand.Easing, moveXCommand.StartTime, moveXCommand.EndTime, moveXCommand.StartValue, moveXCommand.EndValue);
+            else if (command is MoveYCommand moveYCommand)
+                sprite.MoveY(moveYCommand.Easing, moveYCommand.StartTime, moveYCommand.EndTime, moveYCommand.StartValue, moveYCommand.EndValue);
+            else if (command is RotateCommand rotateCommand)
+                sprite.Rotate(rotateCommand.Easing, rotateCommand.StartTime, rotateCommand.EndTime, rotateCommand.StartValue, rotateCommand.EndValue);
+            else if (command is LoopCommand loopCommand)
+            {
+                sprite.StartLoopGroup(loopCommand.StartTime, loopCommand.LoopCount);
+                foreach (var cmd in loopCommand.Commands)
+                    AddCommand(sprite, cmd);
+                sprite.EndGroup();
+            }
+            else if (command is TriggerCommand triggerCommand)
+            {
+                sprite.StartTriggerGroup(triggerCommand.TriggerName, triggerCommand.StartTime, triggerCommand.EndTime, triggerCommand.Group);
+                foreach (var cmd in triggerCommand.Commands)
+                    AddCommand(sprite, cmd);
+                sprite.EndGroup();
+            }
+        }
+
+        public static bool IsFragmentable(this ICommand command)
+        {
+            if (command is ParameterCommand)
+                return true;
+
+            if (command.StartTime == command.EndTime)
+                return true;
+
+            var type = command.GetType();
+            var easingProp = type.GetProperty("Easing");
+            var easing = easingProp.GetValue(command);
+            return (OsbEasing)easing == OsbEasing.None;
+        }
+    }
+}

--- a/common/Storyboarding/OsbSpriteWriter.cs
+++ b/common/Storyboarding/OsbSpriteWriter.cs
@@ -143,16 +143,21 @@ namespace StorybrewCommon.Storyboarding
                 maxCommandCount = (int)Math.Ceiling(commands.Count / 2.0);
 
             if (commands.Count < maxCommandCount)
-                endTime = fragmentationTimes.Max() + 1;
+                endTime = fragmentationTimes.Max();
             else
             {
-                var cEndTime = (int)commands.OrderBy(c => c.StartTime).ElementAt(maxCommandCount - 1).StartTime;
-                if (fragmentationTimes.Contains(cEndTime))
-                    endTime = cEndTime;
+                var lastCommand = commands.OrderBy(c => c.StartTime).ElementAt(maxCommandCount - 1);
+                if (fragmentationTimes.Contains((int)lastCommand.StartTime) && lastCommand.StartTime > startTime)
+                    endTime = (int)lastCommand.StartTime;
                 else
                 {
-                    endTime = fragmentationTimes.Where(t => t < cEndTime).Max();
-                    if (endTime == startTime) // segment can't be <= MaxCommandCount, so we use the smallest available
+                    if (fragmentationTimes.Any(t => t < (int)lastCommand.StartTime))
+                    {
+                        endTime = fragmentationTimes.Where(t => t < (int)lastCommand.StartTime).Max();
+                        if (endTime == startTime) // segment can't be <= MaxCommandCount, so we use the smallest available
+                            endTime = fragmentationTimes.First(t => t > startTime);
+                    }
+                    else
                         endTime = fragmentationTimes.First(t => t > startTime);
                 }
             }

--- a/common/Storyboarding/OsbSpriteWriter.cs
+++ b/common/Storyboarding/OsbSpriteWriter.cs
@@ -13,15 +13,15 @@ namespace StorybrewCommon.Storyboarding
     public class OsbSpriteWriter
 
     {
-        private OsbSprite osbSprite;
-        private AnimatedValue<CommandPosition> moveTimeline;
-        private AnimatedValue<CommandDecimal> moveXTimeline;
-        private AnimatedValue<CommandDecimal> moveYTimeline;
-        private AnimatedValue<CommandDecimal> scaleTimeline;
-        private AnimatedValue<CommandScale> scaleVecTimeline;
-        private AnimatedValue<CommandDecimal> rotateTimeline;
-        private AnimatedValue<CommandDecimal> fadeTimeline;
-        private AnimatedValue<CommandColor> colorTimeline;
+        private readonly OsbSprite osbSprite;
+        private readonly AnimatedValue<CommandPosition> moveTimeline;
+        private readonly AnimatedValue<CommandDecimal> moveXTimeline;
+        private readonly AnimatedValue<CommandDecimal> moveYTimeline;
+        private readonly AnimatedValue<CommandDecimal> scaleTimeline;
+        private readonly AnimatedValue<CommandScale> scaleVecTimeline;
+        private readonly AnimatedValue<CommandDecimal> rotateTimeline;
+        private readonly AnimatedValue<CommandDecimal> fadeTimeline;
+        private readonly AnimatedValue<CommandColor> colorTimeline;
         protected readonly TextWriter TextWriter;
         protected readonly ExportSettings ExportSettings;
         protected readonly OsbLayer OsbLayer;

--- a/common/Storyboarding/OsbSpriteWriter.cs
+++ b/common/Storyboarding/OsbSpriteWriter.cs
@@ -52,10 +52,7 @@ namespace StorybrewCommon.Storyboarding
 
         public void WriteOsb()
         {
-            if (osbSprite.CommandCount == 0)
-                return;
-
-            if (osbSprite.CommandCount > osbSprite.MaxCommandCount && IsFragmentable())
+            if (osbSprite.MaxCommandCount > 0 && osbSprite.CommandCount > osbSprite.MaxCommandCount && IsFragmentable())
             {
                 var fragmentationTimes = GetFragmentationTimes();
                 var commands = osbSprite.Commands.ToList();

--- a/common/Storyboarding/OsbSpriteWriter.cs
+++ b/common/Storyboarding/OsbSpriteWriter.cs
@@ -125,10 +125,20 @@ namespace StorybrewCommon.Storyboarding
         {
             HashSet<int> fragmentationTimes = new HashSet<int>();
             var nonFragmentableCommands = OsbSprite.Commands.Where(c => !c.IsFragmentable()).ToList();
+            HashSet<int> nonFragmentableTimes = new HashSet<int>();
 
-            fragmentationTimes.UnionWith(Enumerable.Range((int)OsbSprite.Commands.Min(c => c.StartTime), (int)OsbSprite.Commands.Max(c => c.EndTime)));
-            //Performance seems not so fresh here (e.g. when using an Easing for the spectrum commands)
-            nonFragmentableCommands.ForEach(c => fragmentationTimes.RemoveWhere(t => t > c.StartTime && t < c.EndTime));
+            int startTime = (int)OsbSprite.Commands.Min(c => c.StartTime);
+            int endTime = (int)OsbSprite.Commands.Max(c => c.EndTime);
+
+            fragmentationTimes.UnionWith(Enumerable.Range(startTime, endTime - startTime));
+            
+            nonFragmentableCommands.ForEach(c =>
+            {
+                var range = Enumerable.Range((int)c.StartTime + 1, (int)(c.EndTime - c.StartTime - 1));
+                nonFragmentableTimes.UnionWith(range);
+            });
+                
+            fragmentationTimes.RemoveWhere(t => nonFragmentableTimes.Contains(t));
 
             return fragmentationTimes;
         }

--- a/common/Storyboarding/OsbSpriteWriter.cs
+++ b/common/Storyboarding/OsbSpriteWriter.cs
@@ -250,42 +250,6 @@ namespace StorybrewCommon.Storyboarding
 
     static class OsbSpriteExtensions
     {
-        public static void AddCommand(this OsbSprite sprite, ICommand command)
-        {
-            if (command is ColorCommand colorCommand)
-                sprite.Color(colorCommand.Easing, colorCommand.StartTime, colorCommand.EndTime, colorCommand.StartValue, colorCommand.EndValue);
-            else if (command is FadeCommand fadeCommand)
-                sprite.Fade(fadeCommand.Easing, fadeCommand.StartTime, fadeCommand.EndTime, fadeCommand.StartValue, fadeCommand.EndValue);
-            else if (command is ScaleCommand scaleCommand)
-                sprite.Scale(scaleCommand.Easing, scaleCommand.StartTime, scaleCommand.EndTime, scaleCommand.StartValue, scaleCommand.EndValue);
-            else if (command is VScaleCommand vScaleCommand)
-                sprite.ScaleVec(vScaleCommand.Easing, vScaleCommand.StartTime, vScaleCommand.EndTime, vScaleCommand.StartValue, vScaleCommand.EndValue);
-            else if (command is ParameterCommand parameterCommand)
-                sprite.Parameter(parameterCommand.Easing, parameterCommand.StartTime, parameterCommand.EndTime, parameterCommand.StartValue);
-            else if (command is MoveCommand moveCommand)
-                sprite.Move(moveCommand.Easing, moveCommand.StartTime, moveCommand.EndTime, moveCommand.StartValue, moveCommand.EndValue);
-            else if (command is MoveXCommand moveXCommand)
-                sprite.MoveX(moveXCommand.Easing, moveXCommand.StartTime, moveXCommand.EndTime, moveXCommand.StartValue, moveXCommand.EndValue);
-            else if (command is MoveYCommand moveYCommand)
-                sprite.MoveY(moveYCommand.Easing, moveYCommand.StartTime, moveYCommand.EndTime, moveYCommand.StartValue, moveYCommand.EndValue);
-            else if (command is RotateCommand rotateCommand)
-                sprite.Rotate(rotateCommand.Easing, rotateCommand.StartTime, rotateCommand.EndTime, rotateCommand.StartValue, rotateCommand.EndValue);
-            else if (command is LoopCommand loopCommand)
-            {
-                sprite.StartLoopGroup(loopCommand.StartTime, loopCommand.LoopCount);
-                foreach (var cmd in loopCommand.Commands)
-                    AddCommand(sprite, cmd);
-                sprite.EndGroup();
-            }
-            else if (command is TriggerCommand triggerCommand)
-            {
-                sprite.StartTriggerGroup(triggerCommand.TriggerName, triggerCommand.StartTime, triggerCommand.EndTime, triggerCommand.Group);
-                foreach (var cmd in triggerCommand.Commands)
-                    AddCommand(sprite, cmd);
-                sprite.EndGroup();
-            }
-        }
-
         public static bool IsFragmentable(this ICommand command)
         {
             if (command is ParameterCommand)

--- a/common/Storyboarding/OsbSpriteWriter.cs
+++ b/common/Storyboarding/OsbSpriteWriter.cs
@@ -52,7 +52,7 @@ namespace StorybrewCommon.Storyboarding
 
         public void WriteOsb()
         {
-            if (ExportSettings.WriteToFile && osbSprite.MaxCommandCount > 0 && osbSprite.CommandCount > osbSprite.MaxCommandCount && IsFragmentable())
+            if (ExportSettings.OptimiseSprites && osbSprite.MaxCommandCount > 0 && osbSprite.CommandCount > osbSprite.MaxCommandCount && IsFragmentable())
             {
                 var commands = osbSprite.Commands.Select(c => (IFragmentableCommand)c)
                                                  .ToList();

--- a/common/Storyboarding/OsbSpriteWriter.cs
+++ b/common/Storyboarding/OsbSpriteWriter.cs
@@ -125,20 +125,14 @@ namespace StorybrewCommon.Storyboarding
         {
             HashSet<int> fragmentationTimes = new HashSet<int>();
             var nonFragmentableCommands = OsbSprite.Commands.Where(c => !c.IsFragmentable()).ToList();
-            HashSet<int> nonFragmentableTimes = new HashSet<int>();
 
-            int startTime = (int)OsbSprite.Commands.Min(c => c.StartTime);
-            int endTime = (int)OsbSprite.Commands.Max(c => c.EndTime);
-
-            fragmentationTimes.UnionWith(Enumerable.Range(startTime, endTime - startTime));
+            fragmentationTimes.UnionWith(Enumerable.Range((int)OsbSprite.StartTime, (int)(OsbSprite.EndTime - OsbSprite.StartTime)));
             
             nonFragmentableCommands.ForEach(c =>
             {
                 var range = Enumerable.Range((int)c.StartTime + 1, (int)(c.EndTime - c.StartTime - 1));
-                nonFragmentableTimes.UnionWith(range);
+                fragmentationTimes.ExceptWith(range);
             });
-                
-            fragmentationTimes.RemoveWhere(t => nonFragmentableTimes.Contains(t));
 
             return fragmentationTimes;
         }

--- a/common/Storyboarding/OsbSpriteWriter.cs
+++ b/common/Storyboarding/OsbSpriteWriter.cs
@@ -121,7 +121,8 @@ namespace StorybrewCommon.Storyboarding
         {
             var fragmentationTimes = new HashSet<int>();
 
-            fragmentationTimes.UnionWith(Enumerable.Range((int)osbSprite.StartTime, (int)(osbSprite.EndTime - osbSprite.StartTime)));
+            //+1 cause from 5 to 10 you have 5 elements from 5 -> 5, 6, 7, 8, 9 but the last one (10) would be missing
+            fragmentationTimes.UnionWith(Enumerable.Range((int)osbSprite.StartTime, (int)(osbSprite.EndTime - osbSprite.StartTime) + 1));
 
             foreach (var command in fragmentableCommands)
                 fragmentationTimes.ExceptWith(command.GetNonFragmentableTimes());

--- a/common/Storyboarding/OsbWriterFactory.cs
+++ b/common/Storyboarding/OsbWriterFactory.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using StorybrewCommon.Storyboarding.CommandValues;
+using StorybrewCommon.Storyboarding.Display;
+
+namespace StorybrewCommon.Storyboarding
+{
+    public class OsbWriterFactory
+    {
+        public static OsbSpriteWriter CreateWriter(OsbSprite osbSprite, AnimatedValue<CommandPosition> moveTimeline,
+                                                                        AnimatedValue<CommandDecimal> moveXTimeline,
+                                                                        AnimatedValue<CommandDecimal> moveYTimeline,
+                                                                        AnimatedValue<CommandDecimal> scaleTimeline,
+                                                                        AnimatedValue<CommandScale> scaleVecTimeline,
+                                                                        AnimatedValue<CommandDecimal> rotateTimeline,
+                                                                        AnimatedValue<CommandDecimal> fadeTimeline,
+                                                                        AnimatedValue<CommandColor> colorTimeline,
+                                                                        TextWriter writer, ExportSettings exportSettings, OsbLayer layer)
+        {
+            if (osbSprite is OsbAnimation osbAnimation)
+            {
+                return new OsbAnimationWriter(osbAnimation, moveTimeline,
+                                                            moveXTimeline,
+                                                            moveYTimeline,
+                                                            scaleTimeline,
+                                                            scaleVecTimeline,
+                                                            rotateTimeline,
+                                                            fadeTimeline,
+                                                            colorTimeline,
+                                                            writer, exportSettings, layer);
+            }
+            else
+            {
+                return new OsbSpriteWriter(osbSprite, moveTimeline,
+                                                      moveXTimeline,
+                                                      moveYTimeline,
+                                                      scaleTimeline,
+                                                      scaleVecTimeline,
+                                                      rotateTimeline,
+                                                      fadeTimeline,
+                                                      colorTimeline,
+                                                      writer, exportSettings, layer);
+            }
+        }
+    }
+}

--- a/common/common.csproj
+++ b/common/common.csproj
@@ -88,6 +88,7 @@
     <Compile Include="Storyboarding3d\PerspectiveCamera.cs" />
     <Compile Include="Storyboarding3d\Scene3d.cs" />
     <Compile Include="Storyboarding3d\Sprite3d.cs" />
+    <Compile Include="Storyboarding\Commands\IFragmentableCommand.cs" />
     <Compile Include="Storyboarding\OsbAnimationWriter.cs" />
     <Compile Include="Storyboarding\OsbSpriteWriter.cs" />
     <Compile Include="Storyboarding\OsbWriterFactory.cs" />

--- a/common/common.csproj
+++ b/common/common.csproj
@@ -90,6 +90,7 @@
     <Compile Include="Storyboarding3d\Sprite3d.cs" />
     <Compile Include="Storyboarding\OsbAnimationWriter.cs" />
     <Compile Include="Storyboarding\OsbSpriteWriter.cs" />
+    <Compile Include="Storyboarding\OsbWriterFactory.cs" />
     <Compile Include="Storyboarding\Util\CommandGenerator.cs" />
     <Compile Include="Storyboarding\OsbSample.cs" />
     <Compile Include="Storyboarding\Util\OsbAnimationPool.cs" />

--- a/common/common.csproj
+++ b/common/common.csproj
@@ -88,6 +88,8 @@
     <Compile Include="Storyboarding3d\PerspectiveCamera.cs" />
     <Compile Include="Storyboarding3d\Scene3d.cs" />
     <Compile Include="Storyboarding3d\Sprite3d.cs" />
+    <Compile Include="Storyboarding\OsbAnimationWriter.cs" />
+    <Compile Include="Storyboarding\OsbSpriteWriter.cs" />
     <Compile Include="Storyboarding\Util\CommandGenerator.cs" />
     <Compile Include="Storyboarding\OsbSample.cs" />
     <Compile Include="Storyboarding\Util\OsbAnimationPool.cs" />

--- a/editor/Storyboarding/EditorStoryboardLayer.cs
+++ b/editor/Storyboarding/EditorStoryboardLayer.cs
@@ -186,6 +186,8 @@ namespace StorybrewEditor.Storyboarding
             estimatedSize = 0;
 
             var exportSettings = new ExportSettings();
+            //removes overhead of optimising the osb in the export, potentially results in estimatedSize being slightly lower than the actual size
+            exportSettings.WriteToFile = false;
             using (var stream = new ByteCounterStream())
             {
                 using (var writer = new StreamWriter(stream, Encoding.UTF8))

--- a/editor/Storyboarding/EditorStoryboardLayer.cs
+++ b/editor/Storyboarding/EditorStoryboardLayer.cs
@@ -186,8 +186,8 @@ namespace StorybrewEditor.Storyboarding
             estimatedSize = 0;
 
             var exportSettings = new ExportSettings();
-            //removes overhead of optimising the osb in the export, potentially results in estimatedSize being slightly lower than the actual size
-            exportSettings.WriteToFile = false;
+            //reduce update time for a minor inaccuracy in estimatedSize
+            exportSettings.OptimiseSprites = false;
             using (var stream = new ByteCounterStream())
             {
                 using (var writer = new StreamWriter(stream, Encoding.UTF8))


### PR DESCRIPTION
Added dedicated writer components to split sprites with a large amount of commands into multiple sprites with less commands during the .osb export in order to optimise performance in osu!.

Tested as "generally working" with no immediately perceivable performance impact for most applicable use cases.

Early PR to gather feedback on the code and to find out to which degree this must be tested in order to merge.