### PR TITLE
Improve user experience for Visual Studio or other IDEs

### DIFF
--- a/editor/Resources/project/scripts.csproj
+++ b/editor/Resources/project/scripts.csproj
@@ -1,32 +1,31 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Output</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{8FED70CF-82ED-4096-AAC0-09FF8BF1C1A0}</ProjectGuid>
     <OutputType>Library</OutputType>
-    <AppDesignerFolder>\</AppDesignerFolder>
+    <TargetFramework>net452</TargetFramework>
+    <Configurations>Output</Configurations>
     <RootNamespace>storyboard</RootNamespace>
     <AssemblyName>storyboard</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
-    <FileAlignment>512</FileAlignment>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
-    <TargetFrameworkProfile />
   </PropertyGroup>
+
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Output|AnyCPU' ">
-    <PlatformTarget>x86</PlatformTarget>
-    <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
-    <OutputPath>\</OutputPath>
-    <IntermediateOutputPath>..\..\cache\obj</IntermediateOutputPath>
-    <DefineConstants>TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
+    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+    <BaseOutputPath>..\..\cache\bin</BaseOutputPath>
+    <BaseIntermediateOutputPath>..\..\cache\obj\</BaseIntermediateOutputPath>
+    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
   </PropertyGroup>
-  <PropertyGroup>
-    <StartupObject />
-  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Remove="obj\**" />
+    <EmbeddedResource Remove="obj\**" />
+    <None Remove="obj\**" />
+    <None Remove=".gitignore" />
+    <None Remove="project.sbrew.yaml" />
+    <None Remove="*.dll" />
+  </ItemGroup>
+
   <ItemGroup>
     <Reference Include="OpenTK">
       <HintPath>..\..\OpenTK.dll</HintPath>
@@ -34,21 +33,8 @@
     <Reference Include="StorybrewCommon">
       <HintPath>..\..\StorybrewCommon.dll</HintPath>
     </Reference>
-    <Reference Include="System" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Drawing" />
-    <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System.Data" />
-    <Reference Include="System.Xml" />
   </ItemGroup>
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
-       Other similar extension points exist, see Microsoft.Common.targets.
-  <Target Name="BeforeBuild">
-  </Target>
-  <Target Name="AfterBuild">
-  </Target>
-  -->
+
 </Project>

--- a/editor/Resources/project/scripts.csproj
+++ b/editor/Resources/project/scripts.csproj
@@ -18,8 +18,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Compile Remove="obj\**" />
-    <EmbeddedResource Remove="obj\**" />
     <None Remove="obj\**" />
     <None Remove=".gitignore" />
     <None Remove="project.sbrew.yaml" />

--- a/editor/Resources/project/storyboard.sln
+++ b/editor/Resources/project/storyboard.sln
@@ -7,8 +7,7 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "scripts", "scripts.csproj",
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
-		Debug|Any CPU = Debug|Any CPU
-		Release|Any CPU = Release|Any CPU
+		Output|Any CPU = Output|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{8FED70CF-82ED-4096-AAC0-09FF8BF1C1A0}.Output|Any CPU.ActiveCfg = Output|Any CPU

--- a/editor/Scripting/ScriptManager.cs
+++ b/editor/Scripting/ScriptManager.cs
@@ -176,7 +176,9 @@ namespace StorybrewEditor.Scripting
             Trace.WriteLine($"Updating solution files");
 
             var slnPath = Path.Combine(ScriptsPath, "storyboard.sln");
-            File.WriteAllBytes(slnPath, resourceContainer.GetBytes("project/storyboard.sln", ResourceSource.Embedded | ResourceSource.Relative));
+            var templateSlnBytes = resourceContainer.GetBytes("project/storyboard.sln", ResourceSource.Embedded | ResourceSource.Relative);
+            if (!File.Exists(slnPath) || !File.ReadAllBytes(slnPath).SequenceEqual(templateSlnBytes))
+                File.WriteAllBytes(slnPath, templateSlnBytes);
 
             var csProjPath = Path.Combine(ScriptsPath, "scripts.csproj");
             var document = new XmlDocument() { PreserveWhitespace = false, };


### PR DESCRIPTION
1. Change template `.sln` file's configurations to `Output` only
2. Change template `.csproj` file to SDK style
3. Not always rewriting `.sln` file but rewriting when content changed

Tested passed for both project migrations and creations on my own storybrew projects.
Migrations: sometimes user should manually delete obj/ in project folder, otherwise `ScriptManager` needs further modification.