### PR TITLE
Fix division by zero error while parsing beatmap files

### DIFF
--- a/editor/Mapset/EditorBeatmap.cs
+++ b/editor/Mapset/EditorBeatmap.cs
@@ -46,13 +46,15 @@ namespace StorybrewEditor.Mapset
         private readonly List<OsuHitObject> hitObjects = new List<OsuHitObject>();
         public override IEnumerable<OsuHitObject> HitObjects => hitObjects;
 
-        private readonly List<Color4> comboColors = new List<Color4>()
+        private static readonly List<Color4> defaultComboColors = new List<Color4>()
         {
             new Color4(255, 192, 0, 255),
             new Color4(0, 202, 0, 255),
             new Color4(18, 124, 255, 255),
             new Color4(242, 24, 57, 255),
         };
+        
+        private readonly List<Color4> comboColors = new List<Color4>(defaultComboColors);
         public override IEnumerable<Color4> ComboColors => comboColors;
 
         public string backgroundPath;
@@ -205,6 +207,11 @@ namespace StorybrewEditor.Mapset
                 var rgb = value.Split(',');
                 beatmap.comboColors.Add(new Color4(byte.Parse(rgb[0]), byte.Parse(rgb[1]), byte.Parse(rgb[2]), 255));
             });
+
+            if (beatmap.comboColors.Count == 0)
+            {
+                beatmap.comboColors.AddRange(defaultComboColors);
+            }
         }
         private static void parseEventsSection(EditorBeatmap beatmap, StreamReader reader)
         {


### PR DESCRIPTION
Beatmaps may have a "Colours" section without any custom combo colors. While parsing such a file, the combo colors are cleared, but none are added, which later produces a division by zero error after trying to assign color index to hit objects.

```
2021-12-23 08:47:19 - StorybrewEditor.Mapset.BeatmapLoadingException: Failed to load beatmap "THE ORAL CIGARETTES - Miss Tail (-Ruben) [monke]". ---> StorybrewCommon.Util.SectionLineParsingFailedException: Failed to parse line "451,134,251,6,0,P|456:189|439:265,1,100.800001230469,8|0,2:0|2:0,2:0:0:0:". ---> System.DivideByZeroException: Attempted to divide by zero.
   at StorybrewEditor.Mapset.EditorBeatmap.<>c__DisplayClass62_0.<parseHitObjectsSection>b__0(String line) in E:\Dev\storybrew\editor\Mapset\EditorBeatmap.cs:line 245
   at StorybrewCommon.Util.StreamReaderExtensions.ParseSectionLines(StreamReader reader, Action`1 action, Boolean trimLines) in E:\Dev\storybrew\common\Util\StreamReaderExtensions.cs:line 36
   --- End of inner exception stack trace ---
   at StorybrewCommon.Util.StreamReaderExtensions.ParseSectionLines(StreamReader reader, Action`1 action, Boolean trimLines) in E:\Dev\storybrew\common\Util\StreamReaderExtensions.cs:line 41
   at StorybrewEditor.Mapset.EditorBeatmap.parseHitObjectsSection(EditorBeatmap beatmap, StreamReader reader) in E:\Dev\storybrew\editor\Mapset\EditorBeatmap.cs:line 234
   at StorybrewEditor.Mapset.EditorBeatmap.<>c__DisplayClass54_1.<Load>b__0(String sectionName) in E:\Dev\storybrew\editor\Mapset\EditorBeatmap.cs:line 131
   at StorybrewCommon.Util.StreamReaderExtensions.ParseSections(StreamReader reader, Action`1 action) in E:\Dev\storybrew\common\Util\StreamReaderExtensions.cs:line 18
   at StorybrewEditor.Mapset.EditorBeatmap.Load(String path) in E:\Dev\storybrew\editor\Mapset\EditorBeatmap.cs:line 120
   --- End of inner exception stack trace ---
   at StorybrewEditor.Mapset.MapsetManager.loadBeatmaps() in E:\Dev\storybrew\editor\Mapset\MapsetManager.cs:line 46
```

This patch defines a list of default combo colors that are used if none were present after parsing the "Colours" section.