### PR TITLE
fix vs constantly reloading csproj

### DIFF
--- a/editor/Scripting/ScriptManager.cs
+++ b/editor/Scripting/ScriptManager.cs
@@ -131,7 +131,7 @@ namespace StorybrewEditor.Scripting
             var change = e.ChangeType.ToString().ToLowerInvariant();
             Trace.WriteLine($"Watched script file {change}: {e.FullPath}");
 
-            if (e.ChangeType != WatcherChangeTypes.Changed)
+            if (e.ChangeType != WatcherChangeTypes.Changed && e.ChangeType != WatcherChangeTypes.Renamed)
                 scheduleSolutionUpdate();
 
             if (e.ChangeType != WatcherChangeTypes.Deleted)


### PR DESCRIPTION
this change makes visual studio not attempt to reload the csproj with each change from within storybrew, nothing else is affected