### PR TITLE
Bored spectrum bars cut off

### DIFF
--- a/common/Scripting/StoryboardObjectGenerator.cs
+++ b/common/Scripting/StoryboardObjectGenerator.cs
@@ -184,6 +184,38 @@ namespace StorybrewCommon.Scripting
             return resultFft;
         }
 
+        /// <summary>
+        /// Returns the Fast Fourier Transform of the song at a certain time, with the specified amount of magnitudes.
+        /// Useful to make spectrum effets.
+        /// </summary>
+        public float[] GetFft(double time, int magnitudes, string path = null, OsbEasing easing = OsbEasing.None, int FrequencyCutOff = 20000, int SamplingRate = 44100)
+        {
+            var fft = GetFft(time, path);
+            if (magnitudes == fft.Length && easing == OsbEasing.None)
+                return fft;
+
+            var usedFftLength = GetLastBucketIndex(FrequencyCutOff, SamplingRate, fft.Length);
+            var resultFft = new float[magnitudes];
+            var baseIndex = 0;
+            for (var i = 0; i < magnitudes; i++)
+            {
+                var progress = EasingFunctions.Ease(easing, (double)i / magnitudes);
+                var index = Math.Min(Math.Max(baseIndex + 1, (int)(progress * usedFftLength)), usedFftLength - 1);
+
+                var value = 0f;
+                for (var v = baseIndex; v < index; v++)
+                    value = Math.Max(value, fft[index]);
+
+                resultFft[i] = value;
+                baseIndex = index;
+            }
+            return resultFft;
+        }
+
+        private int GetLastBucketIndex(int FrequencyCutOff, int SamplingRate, int fftLength)
+        {
+            return (int)Math.Floor(FrequencyCutOff / (SamplingRate / 2.0) * fftLength);
+        }
         #endregion
 
         #region Subtitles

--- a/common/Scripting/StoryboardObjectGenerator.cs
+++ b/common/Scripting/StoryboardObjectGenerator.cs
@@ -161,33 +161,6 @@ namespace StorybrewCommon.Scripting
         /// Returns the Fast Fourier Transform of the song at a certain time, with the specified amount of magnitudes.
         /// Useful to make spectrum effets.
         /// </summary>
-        public float[] GetFft(double time, int magnitudes, string path = null, OsbEasing easing = OsbEasing.None)
-        {
-            var fft = GetFft(time, path);
-            if (magnitudes == fft.Length && easing == OsbEasing.None)
-                return fft;
-
-            var resultFft = new float[magnitudes];
-            var baseIndex = 0;
-            for (var i = 0; i < magnitudes; i++)
-            {
-                var progress = EasingFunctions.Ease(easing, (double)i / magnitudes);
-                var index = Math.Min(Math.Max(baseIndex + 1, (int)(progress * fft.Length)), fft.Length - 1);
-
-                var value = 0f;
-                for (var v = baseIndex; v < index; v++)
-                    value = Math.Max(value, fft[index]);
-
-                resultFft[i] = value;
-                baseIndex = index;
-            }
-            return resultFft;
-        }
-
-        /// <summary>
-        /// Returns the Fast Fourier Transform of the song at a certain time, with the specified amount of magnitudes.
-        /// Useful to make spectrum effets.
-        /// </summary>
         public float[] GetFft(double time, int magnitudes, string path = null, OsbEasing easing = OsbEasing.None, int FrequencyCutOff = 20000, int SamplingRate = 44100)
         {
             var fft = GetFft(time, path);

--- a/scripts/RadialSpectrum.cs
+++ b/scripts/RadialSpectrum.cs
@@ -54,6 +54,12 @@ namespace StorybrewScripts
         [Configurable]
         public OsbEasing FftEasing = OsbEasing.InExpo;
 
+        [Configurable]
+        public int SamplingRate = 44100;
+
+        [Configurable]
+        public int FrequencyCutOff = 16000;
+
         public override void Generate()
         {
             if (StartTime == EndTime)
@@ -74,7 +80,7 @@ namespace StorybrewScripts
             var fftOffset = fftTimeStep * 0.2;
             for (var time = (double)StartTime; time < EndTime; time += fftTimeStep)
             {
-                var fft = GetFft(time + fftOffset, BarCount, null, FftEasing);
+                var fft = GetFft(time + fftOffset, BarCount, null, FftEasing, FrequencyCutOff, SamplingRate);
                 for (var i = 0; i < BarCount; i++)
                 {
                     var height = Radius + (float)Math.Log10(1 + fft[i] * LogScale) * Scale;

--- a/scripts/Spectrum.cs
+++ b/scripts/Spectrum.cs
@@ -54,6 +54,12 @@ namespace StorybrewScripts
         [Configurable]
         public OsbEasing FftEasing = OsbEasing.InExpo;
 
+        [Configurable]
+        public int SamplingRate = 44100;
+
+        [Configurable]
+        public int FrequencyCutOff = 16000;
+
         public override void Generate()
         {
             if (StartTime == EndTime)
@@ -74,7 +80,7 @@ namespace StorybrewScripts
             var fftOffset = fftTimeStep * 0.2;
             for (var time = (double)StartTime; time < EndTime; time += fftTimeStep)
             {
-                var fft = GetFft(time + fftOffset, BarCount, null, FftEasing);
+                var fft = GetFft(time + fftOffset, BarCount, null, FftEasing, FrequencyCutOff, SamplingRate);
                 for (var i = 0; i < BarCount; i++)
                 {
                     var height = (float)Math.Log10(1 + fft[i] * LogScale) * Scale.Y / bitmap.Height;


### PR DESCRIPTION
Reason: 
Many Mp3s used in osu! have a frequency cut off at 16kHz due to the restrictions on audio quality.
The standard Fft always returns the full range of frequencies aka 22050 Hz which leads to the upper end of the frequency range being empty, causing spectrums to normally have some bars that just don't move at all. The existing easing alleviates but doesn't solve this issue.
Why does the optional parameter use 20000 as the standard cut off frequency instead of 22050? Because that's the upper limit human beings can hear, duh.

Other reason:
Most of the music happens between 0 and 3000 Hz and anything above is usually just overtones that mimic what is already happening at lower frequencies so this essentially opens up possibilities for spectrums where individual notes are more visible due to the range of frequencies being used being smaller.


Trivia:
I originally wanted sbrew to find out the samplingRate of the audio by itself but then realised that there is no reference to brewlib or Bass in common at all. Since the user has to check out the song's spectrogram in a third party app anyway, they can just as easily confirm the sampling rate there as well on the off chance that is not 44100.