### PR TITLE
Expose AudioFilename

### DIFF
--- a/common/Mapset/Beatmap.cs
+++ b/common/Mapset/Beatmap.cs
@@ -56,5 +56,7 @@ namespace StorybrewCommon.Mapset
         /// Finds the timing point (red line) active at a specific time.
         /// </summary>
         public abstract ControlPoint GetTimingPointAt(int time);
+
+        public abstract string AudioFilename { get; }
     }
 }

--- a/editor/Mapset/EditorBeatmap.cs
+++ b/editor/Mapset/EditorBeatmap.cs
@@ -14,7 +14,8 @@ namespace StorybrewEditor.Mapset
     {
         public readonly string Path;
 
-        public string AudioFilename { get; set; }
+        public override string AudioFilename => audioFilename;
+        private string audioFilename = "audio.mp3";
 
         private string name = string.Empty;
         public override string Name => name;
@@ -145,7 +146,7 @@ namespace StorybrewEditor.Mapset
             {
                 switch (key)
                 {
-                    case "AudioFilename": beatmap.AudioFilename = value; break;
+                    case "AudioFilename": beatmap.audioFilename = value; break;
                 }
             });
         }


### PR DESCRIPTION
Kinda self-explanatory, hurts noone in any case

actual use case is/was that I was going to create a harmonic spectrum effect with my mentee and for that we need a finer resolution of fft values than storybrew's GetFft gives us but after adding the bass assembly oddly enough we had no way to retrieve the AudioFilename from the Beatmap
Just passing it in via a configurable for now but there isn't a reason not to expose it, is there...