### PR TITLE
Add empty widget value.

### DIFF
--- a/editor/UserInterface/Components/EffectConfigUi.cs
+++ b/editor/UserInterface/Components/EffectConfigUi.cs
@@ -174,6 +174,11 @@ namespace StorybrewEditor.UserInterface.Components
         {
             if (field.AllowedValues != null)
             {
+                if (field.AllowedValues.Length < 1)
+                {
+                    return new EmptyWidget(Manager);
+                } 
+                
                 var widget = new Selectbox(Manager)
                 {
                     Value = field.Value,

--- a/editor/UserInterface/EmptyWidget.cs
+++ b/editor/UserInterface/EmptyWidget.cs
@@ -1,0 +1,10 @@
+﻿using BrewLib.UserInterface;
+
+namespace StorybrewEditor.UserInterface
+{
+    public class EmptyWidget : Widget
+    {
+        public EmptyWidget(WidgetManager manager) : base(manager)
+        { }
+    }
+}


### PR DESCRIPTION
Adds ability to convert Empty Enum values to just text values on the Config UI.
Examples below:
![image](https://user-images.githubusercontent.com/37494321/189536198-e2dda784-081a-429a-b2ef-e4497e66866d.png)
Before

![image](https://user-images.githubusercontent.com/37494321/189536257-09f1d660-899a-4653-9ac1-236c21bb8afe.png)
After

Example Code:
```csharp
public enum EmptyEnum{}
[Configurable(DisplayName = " ----- Main Effect Script -----\n\nHow to use:\n* Sprite Count: how many sprites in a particle\n ")]
public EmptyEnum test;
```