### PR TITLE
Implement IOffsetable for OsbSprite

### DIFF
--- a/common/Storyboarding/Commands/LoopCommand.cs
+++ b/common/Storyboarding/Commands/LoopCommand.cs
@@ -4,7 +4,7 @@ using System.Linq;
 
 namespace StorybrewCommon.Storyboarding.Commands
 {
-    public class LoopCommand : CommandGroup, IFragmentableCommand
+    public class LoopCommand : CommandGroup, IFragmentableCommand, IOffsetable
     {
         public int LoopCount { get; set; }
         public override double EndTime
@@ -65,6 +65,11 @@ namespace StorybrewCommon.Storyboarding.Commands
                 nonFragmentableTimes.UnionWith(Enumerable.Range((int)StartTime + i * (int)CommandsDuration + 1, (int)CommandsDuration - 1));
 
             return nonFragmentableTimes;
+        }
+        
+        public void Offset(double offset)
+        {
+            StartTime += offset;
         }
     }
 }

--- a/common/Storyboarding/OsbSprite.cs
+++ b/common/Storyboarding/OsbSprite.cs
@@ -11,7 +11,7 @@ using System.Linq;
 
 namespace StorybrewCommon.Storyboarding
 {
-    public class OsbSprite : StoryboardObject
+    public class OsbSprite : StoryboardObject, IOffsetable
     {
         public static readonly Vector2 DefaultPosition = new Vector2(320, 240);
 
@@ -205,6 +205,16 @@ namespace StorybrewCommon.Storyboarding
             currentCommandGroup = null;
 
             endDisplayComposites();
+        }
+
+        public void Offset(double offset)
+        {
+            commands.ForEach(command =>
+            {
+                if (command is IOffsetable c)
+                    c.Offset(offset);
+            });
+            clearStartEndTimes();
         }
 
         private void addCommand(ICommand command)


### PR DESCRIPTION
Adds support for offseting a sprite's animation.
When working with staggered animations, I like to work with absolute times first and then offset each sprite's commands to achieve the different startTimes.
Example:
```cs
double stagger = 120;

for(int i = 0; i < 4; i++) {
  var sprite = GetLayer("").CreateSprite(...);
  //Ignoring the different start/end times while adding the commands
  sprite.Move(0, 500, 40, 120);
  sprite.Scale(OsbEasing.OutBack, 0, 500, 1, 2);

  //Move sprite's animation in place 
  sprite.Offset(stagger * i);
}
```