### PR TITLE
Overlapped & Incompatible Command QoL

### DIFF
--- a/editor/ScreenLayers/ProjectMenu.cs
+++ b/editor/ScreenLayers/ProjectMenu.cs
@@ -609,9 +609,16 @@ namespace StorybrewEditor.ScreenLayers
                 warnings += $"⚠ {totalGpuMemory:0.0}MB Texture Mem. (Total)\n";
 
             if (project.FrameStats.OverlappedCommands)
-                warnings += $"⚠ Overlapped Commands\n";
+            {
+                var scriptList = string.Join(", ", project.FrameStats.OverlappedScriptNames);
+                warnings += $"⚠ Overlapped Commands in: {scriptList}\n";
+            }
+
             if (project.FrameStats.IncompatibleCommands)
-                warnings += $"⚠ Incompatible Commands\n";
+            {
+                var scriptList = string.Join(", ", project.FrameStats.IncompatibleScriptNames);
+                warnings += $"⚠ Incompatible Commands in: {scriptList}\n";
+            }
 
             return warnings.TrimEnd('\n');
         }

--- a/editor/Storyboarding/EditorOsbAnimation.cs
+++ b/editor/Storyboarding/EditorOsbAnimation.cs
@@ -7,6 +7,7 @@ namespace StorybrewEditor.Storyboarding
 {
     public class EditorOsbAnimation : OsbAnimation, DisplayableObject, HasPostProcess
     {
+        public string ScriptName { get; set; }
         public void Draw(DrawContext drawContext, Camera camera, Box2 bounds, float opacity, StoryboardTransform transform, Project project, FrameStats frameStats)
             => EditorOsbSprite.Draw(drawContext, camera, bounds, opacity, transform, project, frameStats, this);
 

--- a/editor/Storyboarding/EditorOsbSprite.cs
+++ b/editor/Storyboarding/EditorOsbSprite.cs
@@ -18,6 +18,7 @@ namespace StorybrewEditor.Storyboarding
     {
         public readonly static RenderStates AlphaBlendStates = new RenderStates();
         public readonly static RenderStates AdditiveStates = new RenderStates() { BlendingFactor = new BlendingFactorState(BlendingMode.Additive), };
+        public string ScriptName { get; set; }
 
         public void Draw(DrawContext drawContext, Camera camera, Box2 bounds, float opacity, StoryboardTransform transform, Project project, FrameStats frameStats)
             => Draw(drawContext, camera, bounds, opacity, transform, project, frameStats, this);
@@ -39,8 +40,22 @@ namespace StorybrewEditor.Storyboarding
                 if (!sprite.ShouldBeActive(time))
                     frameStats.ProlongedSpriteCount++;
                 frameStats.CommandCount += sprite.CommandCost;
-                frameStats.IncompatibleCommands |= sprite.HasIncompatibleCommands;
-                frameStats.OverlappedCommands |= sprite.HasOverlappedCommands;
+
+                if (sprite.HasOverlappedCommands)
+                {
+                    frameStats.OverlappedCommands = true;
+                    var editorSprite = sprite as EditorOsbSprite;
+                    if (editorSprite != null && !string.IsNullOrEmpty(editorSprite.ScriptName))
+                        frameStats.OverlappedScriptNames.Add(editorSprite.ScriptName);
+                }
+
+                if (sprite.HasIncompatibleCommands)
+                {
+                    frameStats.IncompatibleCommands = true;
+                    var editorSprite = sprite as EditorOsbSprite;
+                    if (editorSprite != null && !string.IsNullOrEmpty(editorSprite.ScriptName))
+                        frameStats.IncompatibleScriptNames.Add(editorSprite.ScriptName);
+                }
             }
 
             var forceVisible = !sprite.ShouldBeActive(time) && Keyboard.GetState().IsKeyDown(Key.AltLeft);

--- a/editor/Storyboarding/EditorStoryboardSegment.cs
+++ b/editor/Storyboarding/EditorStoryboardSegment.cs
@@ -55,6 +55,7 @@ namespace StorybrewEditor.Storyboarding
                 TexturePath = path,
                 Origin = origin,
                 InitialPosition = initialPosition,
+                ScriptName = Effect.BaseName
             };
             storyboardObjects.Add(storyboardObject);
             displayableObjects.Add(storyboardObject);
@@ -75,6 +76,7 @@ namespace StorybrewEditor.Storyboarding
                 FrameDelay = frameDelay,
                 LoopType = loopType,
                 InitialPosition = initialPosition,
+                ScriptName = Effect.BaseName
             };
             storyboardObjects.Add(storyboardObject);
             displayableObjects.Add(storyboardObject);

--- a/editor/Storyboarding/FrameStats.cs
+++ b/editor/Storyboarding/FrameStats.cs
@@ -16,6 +16,8 @@ namespace StorybrewEditor.Storyboarding
         public int EffectiveCommandCount;
         public bool IncompatibleCommands;
         public bool OverlappedCommands;
+        public HashSet<string> OverlappedScriptNames = new HashSet<string>();
+        public HashSet<string> IncompatibleScriptNames = new HashSet<string>();
 
         public float ScreenFill;
         public ulong GpuPixelsFrame;


### PR DESCRIPTION
Added script name on command overlap and compatibility error messages for better clarity
Before:
![image](https://github.com/user-attachments/assets/d2dfe9a2-61f6-4773-a745-12a20c121bf4)

After:
![image](https://github.com/user-attachments/assets/e07fb105-bd9b-4d48-9934-8e20506db945)

