### PR TITLE
Fix Additional Dependencies Not Loading Properly

### DIFF
--- a/editor/Scripting/ScriptCompiler.cs
+++ b/editor/Scripting/ScriptCompiler.cs
@@ -1,10 +1,14 @@
 ﻿using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.Emit;
+using Microsoft.VisualBasic.ApplicationServices;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
+using System;
 using System.Linq;
+using System.Reflection;
+using System.Reflection.Metadata;
 using System.Text;
 
 namespace StorybrewEditor.Scripting
@@ -15,28 +19,34 @@ namespace StorybrewEditor.Scripting
         {
             Debug.Print($"{nameof(Scripting)}: Compiling {string.Join(", ", sourcePaths)}");
 
-            var syntaxTrees = sourcePaths.Select(path => SyntaxFactory.ParseSyntaxTree(File.ReadAllText(path), path: path)).ToArray();
+            var syntaxTrees = sourcePaths.Select(path => SyntaxFactory.ParseSyntaxTree(File.ReadAllText(path), path: path));
             var references = new List<MetadataReference>();
 
             foreach (var assembly in referencedAssemblies)
                 if (File.Exists(assembly))
                 {
-                    //Debug.WriteLine($"Assembly exists at {assembly}");
 
+                        
+                    //binarie: I have no idea why loading the assembly directly works
+                    //i think maybe the editor needs to have the assembly stored in memory to correctly compile?
+                    Assembly.LoadFrom(assembly);
                     PortableExecutableReference metaRef = MetadataReference.CreateFromFile(assembly);
-                    //Debug.WriteLine(metaRef.Display);
+
                     references.Add(metaRef);
                 }
-
+            
             var compilation = CSharpCompilation.Create(
                 assemblyName: Path.GetFileNameWithoutExtension(outputPath),
-                syntaxTrees: syntaxTrees,
                 references: references,
+                syntaxTrees: syntaxTrees,
                 options: new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+
 
             EmitResult result;
             using (var stream = new FileStream(outputPath, FileMode.Create, FileAccess.Write))
                 result = compilation.Emit(stream);
+
+            
 
             if (!result.Success)
             {

--- a/editor/Scripting/ScriptCompiler.cs
+++ b/editor/Scripting/ScriptCompiler.cs
@@ -20,7 +20,13 @@ namespace StorybrewEditor.Scripting
 
             foreach (var assembly in referencedAssemblies)
                 if (File.Exists(assembly))
-                    references.Add(MetadataReference.CreateFromFile(assembly));
+                {
+                    //Debug.WriteLine($"Assembly exists at {assembly}");
+
+                    PortableExecutableReference metaRef = MetadataReference.CreateFromFile(assembly);
+                    //Debug.WriteLine(metaRef.Display);
+                    references.Add(metaRef);
+                }
 
             var compilation = CSharpCompilation.Create(
                 assemblyName: Path.GetFileNameWithoutExtension(outputPath),

--- a/editor/Scripting/ScriptContainer.cs
+++ b/editor/Scripting/ScriptContainer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using System.Reflection;
 using System.Runtime.Loader;
 
 namespace StorybrewEditor.Scripting
@@ -94,7 +95,8 @@ namespace StorybrewEditor.Scripting
             {
                 currentVersion = localTargetVersion;
 
-                if (disposedValue) throw new ObjectDisposedException(nameof(ScriptContainer<TScript>));
+                ObjectDisposedException.ThrowIf(disposedValue, this);
+                //if (disposedValue) throw new ObjectDisposedException(nameof(ScriptContainer<TScript>));
 
                 try
                 {
@@ -105,6 +107,7 @@ namespace StorybrewEditor.Scripting
                     }
 
                     var assemblyPath = Path.Combine(CompiledScriptsPath, $"{Guid.NewGuid()}.dll");
+
                     ScriptCompiler.Compile(SourcePaths, assemblyPath, ReferencedAssemblies);
 
                     var contextName = $"{Name} {Id}";
@@ -113,7 +116,15 @@ namespace StorybrewEditor.Scripting
 
                     try
                     {
-                        scriptType = assemblyLoadContext.LoadFromAssemblyPath(assemblyPath).GetType(ScriptTypeName);
+                        Assembly assembly = assemblyLoadContext.LoadFromAssemblyPath(assemblyPath);
+                        
+
+                        foreach (AssemblyName assName in assembly.GetReferencedAssemblies())
+                        {
+                            Debug.WriteLine(assName.Name);
+                        }
+                        
+                        scriptType = assembly.GetType(ScriptTypeName);
                         if (scriptType == null)
                             throw new TypeLoadException($"Type {ScriptTypeName} was not found in assembly");
 

--- a/editor/Scripting/ScriptContainer.cs
+++ b/editor/Scripting/ScriptContainer.cs
@@ -118,12 +118,6 @@ namespace StorybrewEditor.Scripting
                     {
                         Assembly assembly = assemblyLoadContext.LoadFromAssemblyPath(assemblyPath);
                         
-
-                        foreach (AssemblyName assName in assembly.GetReferencedAssemblies())
-                        {
-                            Debug.WriteLine(assName.Name);
-                        }
-                        
                         scriptType = assembly.GetType(ScriptTypeName);
                         if (scriptType == null)
                             throw new TypeLoadException($"Type {ScriptTypeName} was not found in assembly");

--- a/editor/Scripting/ScriptManager.cs
+++ b/editor/Scripting/ScriptManager.cs
@@ -29,12 +29,6 @@ namespace StorybrewEditor.Scripting
             set
             {
                 referencedAssemblies = new List<string>(value);
-                //Trace.WriteLine("REFERENCED ASSEMBLIES!");
-                //foreach (var assembly in referencedAssemblies)
-                //{
-                //    Trace.WriteLine(assembly);
-                //}
-                //Trace.WriteLine("\n\n\n\n\n\n\n");
                 foreach (var scriptContainer in scriptContainers.Values)
                     scriptContainer.ReferencedAssemblies = referencedAssemblies;
                 updateSolutionFiles();

--- a/editor/Scripting/ScriptManager.cs
+++ b/editor/Scripting/ScriptManager.cs
@@ -216,17 +216,17 @@ namespace StorybrewEditor.Scripting
                     Trace.Assert(importedAssembly != null);
 
                     compileNode.SetAttribute("Include", importedAssembly.Name);
+                    //var hintPath = document.CreateElement("HintPath", xmlns);
+                    //hintPath.AppendChild(document.CreateTextNode(@$"..\..\{relativePath}"));
+                    //compileNode.AppendChild(hintPath);
+
                     var hintPath = document.CreateElement("HintPath", xmlns);
-                    hintPath.AppendChild(document.CreateTextNode(@$"..\..\{relativePath}"));
-                    compileNode.AppendChild(hintPath);
-                    
-                    hintPath = document.CreateElement("HintPath", xmlns);
                     hintPath.AppendChild(document.CreateTextNode(@$"{relativePath}"));
                     compileNode.AppendChild(hintPath);
 
-                    hintPath = document.CreateElement("HintPath", xmlns);
-                    hintPath.AppendChild(document.CreateTextNode(@$"{path}"));
-                    compileNode.AppendChild(hintPath);
+                    //hintPath = document.CreateElement("HintPath", xmlns);
+                    //hintPath.AppendChild(document.CreateTextNode(@$"{path}"));
+                    //compileNode.AppendChild(hintPath);
 
                     referencedAssembliesGroup.AppendChild(compileNode);
                 }

--- a/editor/Scripting/ScriptManager.cs
+++ b/editor/Scripting/ScriptManager.cs
@@ -1,10 +1,15 @@
 ﻿using BrewLib.Data;
+using BrewLib.Util;
 using StorybrewCommon.Scripting;
+using StorybrewEditor.Storyboarding;
 using StorybrewEditor.Util;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Xml;
 
 namespace StorybrewEditor.Scripting
 {
@@ -24,6 +29,12 @@ namespace StorybrewEditor.Scripting
             set
             {
                 referencedAssemblies = new List<string>(value);
+                //Trace.WriteLine("REFERENCED ASSEMBLIES!");
+                //foreach (var assembly in referencedAssemblies)
+                //{
+                //    Trace.WriteLine(assembly);
+                //}
+                //Trace.WriteLine("\n\n\n\n\n\n\n");
                 foreach (var scriptContainer in scriptContainers.Values)
                     scriptContainer.ReferencedAssemblies = referencedAssemblies;
                 updateSolutionFiles();
@@ -176,7 +187,62 @@ namespace StorybrewEditor.Scripting
                 Directory.CreateDirectory(vsCodePath);
 
             var csProjPath = Path.Combine(ScriptsPath, "scripts.csproj");
-            File.WriteAllBytes(csProjPath, resourceContainer.GetBytes("project/scripts.csproj", ResourceSource.Embedded | ResourceSource.Relative));
+            var document = new XmlDocument() { PreserveWhitespace = false, };
+            try
+            {
+                using (var stream = resourceContainer.GetStream("project/scripts.csproj", ResourceSource.Embedded | ResourceSource.Relative))
+                {
+                    
+                    document.Load(stream);
+                }
+
+                var xmlns = document.DocumentElement.GetAttribute("xmlns");
+                //var compileGroup = document.CreateElement("ItemGroup", xmlns);
+                //document.DocumentElement.AppendChild(compileGroup);
+                //foreach (var path in Directory.EnumerateFiles(ScriptsPath, "*.cs", SearchOption.AllDirectories))
+                //{
+                //    var relativePath = PathHelper.GetRelativePath(ScriptsPath, path);
+
+                //    var compileNode = document.CreateElement("Compile", xmlns);
+                //    compileNode.SetAttribute("Include", relativePath);
+                //    compileGroup.AppendChild(compileNode);
+                //}
+
+                var referencedAssembliesGroup = document.CreateElement("ItemGroup", xmlns);
+                document.DocumentElement.AppendChild(referencedAssembliesGroup);
+                var importedAssemblies = referencedAssemblies.Where(e => !Project.DefaultAssemblies.Contains(e));
+                foreach (var path in importedAssemblies)
+                {
+                    //Trace.WriteLine($"{path} is being imported");
+                    var relativePath = PathHelper.GetRelativePath(ScriptsPath, path);
+
+                    var compileNode = document.CreateElement("Reference", xmlns);
+
+                    AssemblyName importedAssembly = AssemblyName.GetAssemblyName(path);
+                    Trace.Assert(importedAssembly != null);
+
+                    compileNode.SetAttribute("Include", importedAssembly.Name);
+                    var hintPath = document.CreateElement("HintPath", xmlns);
+                    hintPath.AppendChild(document.CreateTextNode(@$"..\..\{relativePath}"));
+                    compileNode.AppendChild(hintPath);
+                    
+                    hintPath = document.CreateElement("HintPath", xmlns);
+                    hintPath.AppendChild(document.CreateTextNode(@$"{relativePath}"));
+                    compileNode.AppendChild(hintPath);
+
+                    hintPath = document.CreateElement("HintPath", xmlns);
+                    hintPath.AppendChild(document.CreateTextNode(@$"{path}"));
+                    compileNode.AppendChild(hintPath);
+
+                    referencedAssembliesGroup.AppendChild(compileNode);
+                }
+                document.Save(csProjPath);
+            }
+            catch (Exception e)
+            {
+                Trace.Fail($"Failed to update scripts.csproj: {e}");
+                //Trace.WriteLine($"Failed to update scripts.csproj: {e}");
+            }
         }
 
         #region IDisposable Support


### PR DESCRIPTION
- Added back additional References and Includes to project's "scripts.csproj" so additional dependencies can be stored and seen properly when editing code.
- Fixed bug where libraries not already loaded into system memory could not be compiled into a script's dependencies.
- Dependencies no longer need to be in Storybrew's root folder in order to reference them.