### PR TITLE
More QOL Stuff and Audio Fixes

### DIFF
--- a/common/Scripting/StoryboardObjectGenerator.cs
+++ b/common/Scripting/StoryboardObjectGenerator.cs
@@ -143,6 +143,11 @@ namespace StorybrewCommon.Scripting
         [Description("Changes the result of Random(...) calls.")]
         [Configurable] public int RandomSeed;
 
+        [Group("Misc")]
+        [Description("Documentation and Helpful Tips")]
+        [Configurable] public string Documentation;
+
+
         private Random random;
         public int Random(int minValue, int maxValue) => random.Next(minValue, maxValue);
         public int Random(int maxValue) => random.Next(maxValue);

--- a/common/Storyboarding/OsbSprite.cs
+++ b/common/Storyboarding/OsbSprite.cs
@@ -1,10 +1,13 @@
-﻿using OpenTK;
+﻿using BrewLib.Graphics.Drawables;
+using OpenTK;
 using StorybrewCommon.Mapset;
+using StorybrewCommon.Scripting;
 using StorybrewCommon.Storyboarding.Commands;
 using StorybrewCommon.Storyboarding.CommandValues;
 using StorybrewCommon.Storyboarding.Display;
 using StorybrewCommon.Storyboarding.Util;
 using StorybrewCommon.Util;
+using System.Transactions;
 
 namespace StorybrewCommon.Storyboarding
 {
@@ -181,6 +184,81 @@ namespace StorybrewCommon.Storyboarding
         {
             initializeDisplayTimelines();
             InitialPosition = DefaultPosition;
+        }
+
+        //necessary delegate so that When<T>'s command can utilize this method to catch all permutations of ____At(time).
+        public delegate T TimeCommandDelegate<T>(double time) where T: CommandValue;
+
+        //threshold for binary search
+        const double TIMESTEP_THRESHOLD = 2.0;
+
+        /// <summary>
+        /// Executes an action when a certain command is within a target (with margin of error).
+        /// </summary>
+        /// <typeparam name="T">Can be any CommandValue.</typeparam>
+        /// <param name="command">The command. This can be <see cref="OpacityAt(double)"/>, <see cref="PositionAt(double)"/>, <see cref="ScaleAt(double)"/>, any command that returns an object
+        /// that implements CommandValue.</param>
+        /// <param name="target">The target value. This must also be a value that can be converted into <typeparamref name="T"/>.</param>
+        /// <param name="actionOnHit">The action that occurs on hit. Argument one is the time that the action hits, and the OsbSprite is this object (callback).</param>
+        /// <param name="marginOfError">The margin of error on the search. This has a default of 0.01 as that is the most consistent margin of error through testing.</param>
+        /// <param name="searchStart">The start of the search. If left not filled, this gets set to <see cref="StartTime"/></param>
+        /// <param name="searchEnd">The end of the search. If left not filled, this gets set to <see cref="EndTime"/></param>
+        public void When<T>(TimeCommandDelegate<T> command, 
+                T target, 
+                Action<double, OsbSprite> actionOnHit,
+                float marginOfError = 0.01f,
+                double searchStart = 0, double searchEnd = 0)
+            where T:CommandValue
+        {
+            if (command.Target != this)
+            {
+                StoryboardObjectGenerator.Current.Log("Improperly formatted search: command must stem from same instance invoking When<> method");
+                return;
+            }
+            if (searchEnd == 0) searchEnd = EndTime;
+            if (searchStart == 0) searchStart = StartTime;
+
+
+            double timestep = (searchEnd - searchStart)*0.5;
+            double time = searchStart;
+            
+            float previousDifference = 10e9f, currentDistance;
+            T currentValue;
+            while (timestep >= TIMESTEP_THRESHOLD)
+            {
+                if (time > searchEnd)
+                {
+                    StoryboardObjectGenerator.Current.Log($"Request for search did not work. Vector never gets within margin of error of " + target.ToString());
+                    return;
+                }
+                currentValue = command.Invoke(time);
+                currentDistance = Math.Abs(currentValue.DistanceFrom(target));
+                
+
+                if (currentDistance < previousDifference)
+                {
+                    if (currentDistance < marginOfError)
+                    {
+                        actionOnHit.Invoke(time, this);
+                        
+                        return;
+                    }
+
+                    else
+                    {
+                        time -= timestep;
+                        timestep *= 0.5;
+                        previousDifference = currentDistance;
+                    }
+                }
+
+                
+                
+
+                time += timestep;
+            }
+
+            actionOnHit.Invoke(time + timestep, this);
         }
 
         public void Move(OsbEasing easing, double startTime, double endTime, CommandPosition startPosition, CommandPosition endPosition) => addCommand(new MoveCommand(easing, startTime, endTime, startPosition, endPosition));

--- a/common/Subtitles/FontGenerator.cs
+++ b/common/Subtitles/FontGenerator.cs
@@ -1,6 +1,7 @@
 ﻿using BrewLib.Util;
 using OpenTK;
 using OpenTK.Graphics;
+using StorybrewCommon.Scripting;
 using StorybrewCommon.Storyboarding;
 using StorybrewCommon.Util;
 using System.Diagnostics;
@@ -8,6 +9,8 @@ using System.Drawing;
 using System.Drawing.Drawing2D;
 using System.Drawing.Imaging;
 using System.Drawing.Text;
+using System.Reflection.Metadata.Ecma335;
+using System.Runtime.InteropServices;
 using Tiny;
 
 namespace StorybrewCommon.Subtitles
@@ -62,6 +65,8 @@ namespace StorybrewCommon.Subtitles
         public bool TrimTransparency;
         public bool EffectsOnly;
         public bool Debug;
+
+        public Func<Bitmap, Bitmap> FinalActions = (bmp) => bmp;
     }
 
     public class FontGenerator
@@ -72,6 +77,8 @@ namespace StorybrewCommon.Subtitles
         private readonly string projectDirectory;
         private readonly string assetDirectory;
 
+        private bool generatingAsLightmap = false;
+
         private readonly Dictionary<string, FontTexture> textureCache = new Dictionary<string, FontTexture>();
 
         internal FontGenerator(string directory, FontDescription description, FontEffect[] effects, string projectDirectory, string assetDirectory)
@@ -81,6 +88,25 @@ namespace StorybrewCommon.Subtitles
             this.effects = effects;
             this.projectDirectory = projectDirectory;
             this.assetDirectory = assetDirectory;
+        }
+
+        
+        public void GenerateTexturesAsLightmap()
+        {
+            if (generatingAsLightmap) return;
+            description.FinalActions = BitmapHelper.MakeIntoLightmap;
+
+            //wanted to add this tooltip
+            StoryboardObjectGenerator.Current.Log(
+                                "Tips for generating as lightmap:\n" +
+                                "1. You can get a border around your text by using the FontOutline effect and\n" +
+                                "setting your main text's color to Black.\n" +
+                                "2. You can also get a gradient on the inside of your text by using the FontGradient effect.\n\n" +
+                                
+                                "If your effects aren't loading, delete the folder and reload your script!");
+
+            generatingAsLightmap = true;
+
         }
 
         public FontTexture GetTexture(string text)
@@ -191,14 +217,24 @@ namespace StorybrewCommon.Subtitles
                                 height = trimmedBitmap.Height;
                                 using (var trimGraphics = Graphics.FromImage(trimmedBitmap))
                                     trimGraphics.DrawImage(bitmap, 0, 0, trimBounds, GraphicsUnit.Pixel);
-                                BrewLib.Util.Misc.WithRetries(() => trimmedBitmap.Save(bitmapPath, ImageFormat.Png));
+
+                                FinalTouchesAndSave(trimmedBitmap, bitmapPath, ImageFormat.Png);
+                                //BrewLib.Util.Misc.WithRetries(() => trimmedBitmap.Save(bitmapPath, ImageFormat.Png));
                             }
                         }
-                        else BrewLib.Util.Misc.WithRetries(() => bitmap.Save(bitmapPath, ImageFormat.Png));
+                        else FinalTouchesAndSave(bitmap, bitmapPath, ImageFormat.Png);
+                        //else BrewLib.Util.Misc.WithRetries(() => bitmap.Save(bitmapPath, ImageFormat.Png));
                     }
                 }
             }
             return new FontTexture(Path.Combine(Directory, filename), offsetX, offsetY, baseWidth, baseHeight, width, height);
+        }
+
+        void FinalTouchesAndSave(Bitmap bitmap, string bitmapPath, ImageFormat format)
+        {
+            Bitmap postProcess = description.FinalActions.Invoke(bitmap);
+
+            BrewLib.Util.Misc.WithRetries((() => postProcess.Save(bitmapPath, format)));
         }
 
         internal void HandleCache(TinyToken cachedFontRoot)

--- a/common/Util/BitmapHelper.cs
+++ b/common/Util/BitmapHelper.cs
@@ -240,6 +240,74 @@ namespace StorybrewCommon.Util
             return Rectangle.Intersect(Rectangle.FromLTRB(xMin - 1, yMin - 1, xMax + 2, yMax + 2), new Rectangle(0, 0, source.Width, source.Height));
         }
 
+        /// <summary>
+        /// Converts a bitmap into a representation of a lightmap, where all pixels are converted to an average
+        /// then are made transparent by how close the pixel color is to black.
+        /// </summary>
+        /// <param name="bmp"></param>
+        /// <returns></returns>
+        public static Bitmap MakeIntoLightmap(Bitmap bmp)
+        {
+
+            BitmapData bmpData = bmp.LockBits(new Rectangle(Point.Empty, bmp.Size), ImageLockMode.ReadWrite, PixelFormat.Format32bppArgb);
+            //for (int x = 0; x < bmp.Width; x++)
+            //{
+            //    for (int y = 0; y < bmp.Height; y++)
+            //    {
+            //        Color p = bmp.GetPixel(x, y);
+            //        byte avg = p.R;
+            //        //Console.WriteLine(avg);
+
+            //        int opacity = p.A == 0 ? 0 : avg & p.A;
+            //        //Console.WriteLine(avg);
+            //        if (opacity > 255) opacity = 255;
+            //        bmp.SetPixel(x, y, Color.FromArgb(opacity, 0xff, 0xff, 0xff));
+
+
+            //    }
+            //}
+
+            byte[] buffer = new byte[bmpData.Stride * bmpData.Height];
+            Marshal.Copy(bmpData.Scan0, buffer, 0, buffer.Length);
+
+            byte sourceRed, sourceGreen, sourceBlue, sourceAlpha;
+
+            int avg;
+            int nextAlpha;
+            byte maxByte = 0xff;
+            for (int i = 0; i < buffer.Length; i += 4)
+            {
+                sourceRed = buffer[i];
+                sourceGreen = buffer[i + 1];
+                sourceBlue = buffer[i + 2];
+                sourceAlpha = buffer[i + 3];
+
+                avg = sourceRed + sourceGreen + sourceBlue;
+                avg /= 3;
+
+                nextAlpha = (sourceAlpha == 0x0 ?
+                                        0x0 :
+                                        avg & sourceAlpha);
+
+
+                if (nextAlpha > maxByte) nextAlpha = maxByte;
+
+                buffer[i] = maxByte;
+                buffer[i + 1] = maxByte;
+                buffer[i + 2] = maxByte;
+                buffer[i + 3] = (byte)nextAlpha;
+
+            }
+
+
+
+            Marshal.Copy(buffer, 0, bmpData.Scan0, buffer.Length);
+            bmp.UnlockBits(bmpData);
+
+            return bmp;
+
+        }
+
         public class PinnedBitmap : IDisposable
         {
             private GCHandle handle;

--- a/editor/Builder.cs
+++ b/editor/Builder.cs
@@ -13,7 +13,7 @@ namespace StorybrewEditor
     public class Builder
     {
         private static readonly string mainExecutablePath = "StorybrewEditor.exe";
-        private static readonly string[] ignoredPaths = { };
+        private static readonly string[] ignoredPaths = Array.Empty<string>();
 
         public static void Build()
         {

--- a/editor/Mapset/BeatmapLoadingException.cs
+++ b/editor/Mapset/BeatmapLoadingException.cs
@@ -18,7 +18,7 @@ namespace StorybrewEditor.Mapset
         {
         }
 
-        protected BeatmapLoadingException(SerializationInfo info, StreamingContext context) : base(info, context)
+        protected BeatmapLoadingException(SerializationInfo info, StreamingContext context)
         {
         }
     }

--- a/editor/Resources/scripttemplate.csx
+++ b/editor/Resources/scripttemplate.csx
@@ -6,6 +6,7 @@ using StorybrewCommon.Storyboarding;
 using StorybrewCommon.Storyboarding.Util;
 using StorybrewCommon.Subtitles;
 using StorybrewCommon.Util;
+using StorybrewCommon.Storyboarding.CommandValues;
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/editor/ScreenLayers/AudioHelpConfig.cs
+++ b/editor/ScreenLayers/AudioHelpConfig.cs
@@ -1,0 +1,69 @@
+﻿using BrewLib.Audio;
+using BrewLib.UserInterface;
+using BrewLib.Util;
+using ManagedBass;
+using StorybrewEditor.Storyboarding;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace StorybrewEditor.ScreenLayers
+{
+    internal class AudioHelpConfig : UiScreenLayer
+    {
+        private LinearLayout layout;
+        private List<DeviceInfo> devices;
+        private LinearLayout buttonsLayout;
+        private Button okButton;
+        private Button cancelButton;
+
+        public override void Load()
+        {
+            base.Load();
+            devices = new List<DeviceInfo>();
+            for (int i = 1; i <= Bass.DeviceCount; i++)
+            {
+                if (Bass.GetDeviceInfo(i, out DeviceInfo info))
+                {
+                    devices.Add(info);
+                }
+            }
+
+            WidgetManager.Root.Add(layout = new LinearLayout(WidgetManager)
+            {
+                StyleName = "panel",
+                AnchorTarget = WidgetManager.Root,
+                AnchorFrom = BoxAlignment.Centre,
+                AnchorTo = BoxAlignment.Centre,
+                Padding = new FourSide(16),
+                FitChildren = true,
+                Fill = true,
+                Children = new Widget[]
+                {
+                    buttonsLayout = new LinearLayout(WidgetManager)
+                    {
+                        Horizontal = true,
+                        Fill = true,
+                        AnchorFrom = BoxAlignment.Centre,
+                        CanGrow = false,
+                        Children = new Widget[]
+                        {
+                            okButton = new Button(WidgetManager)
+                            {
+                                Text = "Ok",
+                                AnchorFrom = BoxAlignment.Centre,
+                            }
+                        },
+                    },
+                }
+            });
+
+            okButton.OnClick += (sender, e) =>
+            {
+                Exit();
+            };
+        }
+    }
+}

--- a/editor/Scripting/ScriptCompilationException.cs
+++ b/editor/Scripting/ScriptCompilationException.cs
@@ -18,7 +18,7 @@ namespace StorybrewEditor.Scripting
         {
         }
 
-        protected ScriptCompilationException(SerializationInfo info, StreamingContext context) : base(info, context)
+        protected ScriptCompilationException(SerializationInfo info, StreamingContext context)
         {
         }
     }

--- a/editor/UserInterface/Components/LayerList.cs
+++ b/editor/UserInterface/Components/LayerList.cs
@@ -4,7 +4,9 @@ using OpenTK;
 using StorybrewCommon.Storyboarding;
 using StorybrewEditor.Storyboarding;
 using System;
+using System.Collections.Generic;
 using System.Linq;
+using System.Text;
 
 namespace StorybrewEditor.UserInterface.Components
 {
@@ -108,6 +110,7 @@ namespace StorybrewEditor.UserInterface.Components
                 var effect = layer.Effect;
 
                 Widget layerRoot;
+                LinearLayout nameAndDetailLayout;
                 Label nameLabel, detailsLabel;
                 Button diffSpecificButton, showHideButton;
                 layersLayout.Add(layerRoot = new LinearLayout(Manager)
@@ -128,7 +131,7 @@ namespace StorybrewEditor.UserInterface.Components
                             AnchorTo = BoxAlignment.Centre,
                             CanGrow = false,
                         },
-                        new LinearLayout(Manager)
+                        nameAndDetailLayout = new LinearLayout(Manager)
                         {
                             StyleName = "condensed",
                             Children = new Widget[]
@@ -147,6 +150,7 @@ namespace StorybrewEditor.UserInterface.Components
                                     AnchorFrom = BoxAlignment.Left,
                                     AnchorTo = BoxAlignment.Left,
                                 },
+                                
                             },
                         },
                         diffSpecificButton = new Button(Manager)
@@ -233,8 +237,44 @@ namespace StorybrewEditor.UserInterface.Components
         }
 
         private static string getLayerDetails(EditorStoryboardLayer layer, Effect effect)
-            => layer.EstimatedSize > 40 * 1024 ?
+        {
+            string usingData = 
+                                layer.EstimatedSize > 40 * 1024 ?
                 $"using {effect.BaseName} ({StringHelper.ToByteSize(layer.EstimatedSize)})" :
                 $"using {effect.BaseName}";
+
+            string separator = "\nLayers:\n";
+
+            //return usingData;
+            string segmentString = GetSegments(layer);
+
+            return layer.NamedSegments.Any() ? string.Concat(usingData, separator, segmentString.AsSpan(0, Math.Min(segmentString.Length, 128))) :
+                usingData;
+
+
+        }
+
+        private static string GetSegments(EditorStoryboardLayer segment)
+        {
+            
+            if (!segment.NamedSegments.Any()) return String.Empty;
+
+            string separator = new string(':', 2) + ' ';
+            StringBuilder builder = new StringBuilder();
+            foreach (var child in segment.NamedSegments)
+            {
+                
+                builder.AppendLine(separator + child.Identifier);
+
+                ////this check only exists as builder.AppendLine will create extra new lines and we don't like that
+                //if (child.NamedSegments.Any())
+                //    builder.AppendLine(GetSegments(child));
+            }
+
+            return builder.Length > 64 ? string.Concat(builder.ToString().AsSpan(0, 61), "...")
+                : builder.ToString();
+        }
+
+        
     }
 }

--- a/editor/UserInterface/Components/LayerList.cs
+++ b/editor/UserInterface/Components/LayerList.cs
@@ -243,14 +243,14 @@ namespace StorybrewEditor.UserInterface.Components
                 $"using {effect.BaseName} ({StringHelper.ToByteSize(layer.EstimatedSize)})" :
                 $"using {effect.BaseName}";
 
-            string separator = "\nLayers:\n";
+            //string separator = "\nLayers:\n";
 
-            //return usingData;
-            string segmentString = GetSegments(layer);
+            ////return usingData;
+            //string segmentString = GetSegments(layer);
 
-            return layer.NamedSegments.Any() ? string.Concat(usingData, separator, segmentString.AsSpan(0, Math.Min(segmentString.Length, 128))) :
-                usingData;
-
+            //return layer.NamedSegments.Any() ? string.Concat(usingData, separator, segmentString.AsSpan(0, Math.Min(segmentString.Length, 128))) :
+            //    usingData;
+            return usingData;
 
         }
 

--- a/editor/UserInterface/Components/SettingsMenu.cs
+++ b/editor/UserInterface/Components/SettingsMenu.cs
@@ -4,6 +4,9 @@ using OpenTK;
 using StorybrewEditor.ScreenLayers;
 using StorybrewEditor.Storyboarding;
 using System.Diagnostics;
+using ManagedBass;
+using System.Collections.Generic;
+using ManagedBass.Fx;
 
 namespace StorybrewEditor.UserInterface.Components
 {
@@ -16,9 +19,13 @@ namespace StorybrewEditor.UserInterface.Components
         public override Vector2 MaxSize => layout.MaxSize;
         public override Vector2 PreferredSize => layout.PreferredSize;
 
+        //The system's current devices are mapped via int.
+        Dictionary<string, int> deviceMap;
+
         public SettingsMenu(WidgetManager manager, Project project) : base(manager)
         {
             this.project = project;
+
 
             Button referencedAssemblyButton, floatingPointTimeButton, audioHelpButton, helpButton;
             Label dimLabel;
@@ -103,7 +110,22 @@ namespace StorybrewEditor.UserInterface.Components
                 FileName = $"https://github.com/{Program.Repository}/wiki",
                 UseShellExecute = true
             });
-            audioHelpButton.OnClick += (sender, e) => Manager.ScreenLayerManager.Add(new AudioHelpConfig());
+            audioHelpButton.OnClick += (sender, e) =>
+            {
+                deviceMap = new Dictionary<string, int>();
+                for (int i = 1; i < Bass.DeviceCount; i++)
+                {
+                    if (Bass.GetDeviceInfo(i, out DeviceInfo info) && info.IsEnabled)
+                    {
+                        deviceMap[info.Name] = i;
+                        Debug.WriteLine($"{info.Name} - {i}");
+                    }
+                }
+                Manager.ScreenLayerManager.ShowContextMenu("Choose output device.", (s) =>
+                {
+                    Program.AudioManager.SwapAudioOutputDevice(deviceMap[s]);
+                }, deviceMap.Keys);
+            };
             referencedAssemblyButton.OnClick += (sender, e) => Manager.ScreenLayerManager.Add(new ReferencedAssemblyConfig(project));
             dimSlider.OnValueChanged += (sender, e) =>
             {

--- a/editor/UserInterface/Components/SettingsMenu.cs
+++ b/editor/UserInterface/Components/SettingsMenu.cs
@@ -20,7 +20,7 @@ namespace StorybrewEditor.UserInterface.Components
         {
             this.project = project;
 
-            Button referencedAssemblyButton, floatingPointTimeButton, helpButton;
+            Button referencedAssemblyButton, floatingPointTimeButton, audioHelpButton, helpButton;
             Label dimLabel;
             Slider dimSlider;
 
@@ -86,6 +86,13 @@ namespace StorybrewEditor.UserInterface.Components
                                 Checked = project.ExportSettings.UseFloatForTime,
                                 Tooltip = "A storyboard exported with this option enabled\nwill only be compatible with lazer",
                             },
+                            audioHelpButton = new Button(manager)
+                            {
+                                Text = "Audio Help",
+                                AnchorFrom = BoxAlignment.Centre,
+                                AnchorTo = BoxAlignment.Centre,
+                                Tooltip = "Use this to help with audio troubles."
+                            }
                         }
                     }
                 },
@@ -96,6 +103,7 @@ namespace StorybrewEditor.UserInterface.Components
                 FileName = $"https://github.com/{Program.Repository}/wiki",
                 UseShellExecute = true
             });
+            audioHelpButton.OnClick += (sender, e) => Manager.ScreenLayerManager.Add(new AudioHelpConfig());
             referencedAssemblyButton.OnClick += (sender, e) => Manager.ScreenLayerManager.Add(new ReferencedAssemblyConfig(project));
             dimSlider.OnValueChanged += (sender, e) =>
             {

--- a/editor/UserInterface/Components/SettingsMenu.cs
+++ b/editor/UserInterface/Components/SettingsMenu.cs
@@ -84,6 +84,12 @@ namespace StorybrewEditor.UserInterface.Components
                                     },
                                 }
                             },
+                            audioHelpButton = new Button(manager)
+                            {
+                                Text = "Swap Output Device",
+                                AnchorFrom = BoxAlignment.Centre,
+                                AnchorTo = BoxAlignment.Centre,
+                            },
                             floatingPointTimeButton = new Button(manager)
                             {
                                 Text = "Export Time as Floating Point",
@@ -92,14 +98,8 @@ namespace StorybrewEditor.UserInterface.Components
                                 Checkable = true,
                                 Checked = project.ExportSettings.UseFloatForTime,
                                 Tooltip = "A storyboard exported with this option enabled\nwill only be compatible with lazer",
-                            },
-                            audioHelpButton = new Button(manager)
-                            {
-                                Text = "Audio Help",
-                                AnchorFrom = BoxAlignment.Centre,
-                                AnchorTo = BoxAlignment.Centre,
-                                Tooltip = "Use this to help with audio troubles."
                             }
+                            
                         }
                     }
                 },


### PR DESCRIPTION
**Texture Generation Improvements**
1. Add ability to make FontTextures generate as lightmaps for better transparency in end product.
2. Add ability to add custom final action logic after texture generation for each Bitmap for FontTexture.

**Sprite Improvements**
1. Can now have action logic when an OsbSprite's values are within a threshold using the When<> function

**Settings**
1. Can now update the output device for audio in the Settings tab. This does work while the map is playing.

Feature removed: transforms-ui has a better solution
**Misc.**
1. Can now see first layer of child segments inside of the Layers tab as extra bits of text. Since these are directly tied to the layers, they are not separate entities and cannot be edited, but I figured it would be a good form of acknowledgement. 