### PR TITLE
Transform Saving and UI

### DIFF
--- a/common/Storyboarding/CommandValues/CommandParameter.cs
+++ b/common/Storyboarding/CommandValues/CommandParameter.cs
@@ -42,5 +42,10 @@
 
         public static implicit operator bool(CommandParameter obj)
             => obj.Type != ParameterType.None;
+
+        public override bool Equals(object obj)
+        {
+            return obj is CommandParameter p && p == this;
+        }
     }
 }

--- a/common/Storyboarding/Commands/MoveCommand.cs
+++ b/common/Storyboarding/Commands/MoveCommand.cs
@@ -28,5 +28,50 @@ namespace StorybrewCommon.Storyboarding.Commands
             }
             return this;
         }
+
+        //public static IEnumerable<MoveCommand> InterpolateFrom(IEnumerable<MoveXCommand> xcommands, IEnumerable<MoveYCommand> ycommands)
+        //{
+        //    xcommands = xcommands.OrderBy((e) => e.StartTime);
+        //    ycommands = ycommands.OrderBy((e) => e.StartTime);
+
+            
+        //    double endTime = Math.Max(xcommands.Last().EndTime, ycommands.Last().EndTime);
+
+        //    Command<CommandDecimal> xCommand;
+        //    Command<CommandDecimal> yCommand;
+
+        //    int xIndex = 0, yIndex = 0;
+        //    int xStart, yStart, xEnd, yEnd;
+
+        //    while (xcommands.Any() || ycommands.Any())
+        //    {
+        //        xCommand = xcommands.ElementAtOrDefault(xIndex);
+        //        yCommand = ycommands.ElementAtOrDefault(yIndex);
+
+        //        xStart = (int)xCommand.StartTime;
+        //        xEnd = (int)xCommand.EndTime;
+
+        //        yStart = (int)yCommand.StartTime;
+        //        yEnd = (int)yCommand.EndTime;
+
+        //        //exact match
+        //        if (xStart == yStart && xEnd == yEnd &&
+        //            xCommand.Easing == yCommand.Easing)
+        //        {
+        //            yield return new MoveCommand(
+        //                xCommand.Easing, xCommand.StartTime, xCommand.EndTime,
+        //                new CommandPosition(xCommand.StartValue, yCommand.StartValue), new CommandPosition(xCommand.EndValue, yCommand.EndValue));
+
+        //            xIndex++;
+        //            yIndex++;
+                    
+        //        }
+
+        //        if (xStart > yEnd)
+        //        {
+
+        //        }  
+
+        //}
     }
 }

--- a/common/Storyboarding/OsbSprite.cs
+++ b/common/Storyboarding/OsbSprite.cs
@@ -344,7 +344,8 @@ namespace StorybrewCommon.Storyboarding
             //set up defaults for the timeline
             if (transform != null)
             {
-                if (transform.Rotates && !rotateTimeline.HasCommands)
+                //if no default has been set for these commands, make sure to add one
+                if (transform.Rotates && !rotateTimeline.HasCommands && !LockRotationOnTransform)
                 {
                     Rotate(StartTime, 0);
                 }

--- a/common/Storyboarding/OsbSprite.cs
+++ b/common/Storyboarding/OsbSprite.cs
@@ -341,6 +341,29 @@ namespace StorybrewCommon.Storyboarding
         {
             if (CommandCount == 0)
                 return;
+            //set up defaults for the timeline
+            if (transform != null)
+            {
+                if (transform.Rotates && !rotateTimeline.HasCommands)
+                {
+                    Rotate(StartTime, 0);
+                }
+
+                if (transform.Scales &&
+                    (!scaleTimeline.HasCommands &&
+                    scaleVecTimeline.HasCommands))
+                {
+                    Scale(StartTime, ScaleAt(StartTime).X);
+                }
+
+                if (transform.Translates &&
+                    (!moveTimeline.HasCommands &&
+                    !moveXTimeline.HasCommands &&
+                    !moveYTimeline.HasCommands))
+                {
+                    Move(StartTime, DefaultPosition);
+                }
+            }
 
             var osbSpriteWriter = OsbWriterFactory.CreateWriter(this, moveTimeline,
                                                                       moveXTimeline,

--- a/common/Storyboarding/OsbSprite.cs
+++ b/common/Storyboarding/OsbSprite.cs
@@ -77,6 +77,7 @@ namespace StorybrewCommon.Storyboarding
         public bool HasScalingCommands => scaleTimeline.HasCommands || scaleVecTimeline.HasCommands;
         public bool HasMoveXYCommands => moveXTimeline.HasCommands || moveYTimeline.HasCommands;
 
+        public bool LockRotationOnTransform { get; set; } = false;
         private double commandsStartTime = double.MaxValue;
         public double CommandsStartTime
         {

--- a/common/Storyboarding/OsbSpriteWriter.cs
+++ b/common/Storyboarding/OsbSpriteWriter.cs
@@ -1,4 +1,6 @@
-﻿using StorybrewCommon.Storyboarding.Commands;
+﻿using BrewLib.Graphics.Drawables;
+using StorybrewCommon.Scripting;
+using StorybrewCommon.Storyboarding.Commands;
 using StorybrewCommon.Storyboarding.CommandValues;
 using StorybrewCommon.Storyboarding.Display;
 
@@ -18,6 +20,8 @@ namespace StorybrewCommon.Storyboarding
         protected readonly TextWriter TextWriter;
         protected readonly ExportSettings ExportSettings;
         protected readonly OsbLayer OsbLayer;
+
+        const double interpolationTimestep = 30;
 
         public OsbSpriteWriter(OsbSprite osbSprite, AnimatedValue<CommandPosition> moveTimeline,
                                                     AnimatedValue<CommandDecimal> moveXTimeline,
@@ -77,9 +81,34 @@ namespace StorybrewCommon.Storyboarding
 
         private void writeOsbSprite(OsbSprite sprite, StoryboardTransform transform)
         {
+            
             WriteHeader(sprite, transform);
-            foreach (var command in sprite.Commands)
+
+            IEnumerable<ICommand> commands = sprite.Commands;
+            
+            foreach (var command in commands)
                 command.WriteOsb(TextWriter, ExportSettings, transform, 1);
+            
+        }
+
+        private List<ICommand> GetInterpolatedCommands(OsbSprite sprite, double start, IEnumerable<ICommand> commands)
+        {
+            Command<CommandDecimal> lastCommand = null, nextCommand;
+            IEnumerable<MoveXCommand> moveXCommands = commands.OfType<MoveXCommand>();
+            IEnumerable<MoveYCommand> moveYCommands = commands.OfType<MoveYCommand>();
+
+            commands = commands.Where((e) => e is not MoveXCommand && e is not MoveYCommand);
+            
+
+            List<ICommand> filteredSpriteCommands = new List<ICommand>();
+
+            foreach (var command in commands)
+            {
+                filteredSpriteCommands.Add(command);
+            }
+            //filteredSpriteCommands.AddRange(MoveCommand.InterpolateFrom(moveXCommands, moveYCommands));
+
+            return filteredSpriteCommands;
         }
 
         protected virtual void WriteHeader(OsbSprite sprite, StoryboardTransform transform)

--- a/common/Storyboarding/OsbSpriteWriter.cs
+++ b/common/Storyboarding/OsbSpriteWriter.cs
@@ -98,7 +98,7 @@ namespace StorybrewCommon.Storyboarding
                 sprite.HasMoveXYCommands ? 
                     transform.ApplyToPositionXY(sprite.InitialPosition) : 
                     transform.ApplyToPosition(sprite.InitialPosition);
-
+            
             if (!moveTimeline.HasCommands && !moveXTimeline.HasCommands)
                 TextWriter.Write($",{transformedInitialPosition.X.ToString(ExportSettings.NumberFormat)}");
             else TextWriter.Write($",0");

--- a/common/Storyboarding/StoryboardTransform.cs
+++ b/common/Storyboarding/StoryboardTransform.cs
@@ -16,6 +16,8 @@ namespace StorybrewCommon.Storyboarding
         private readonly float transformScale;
         private readonly double transformAngle;
 
+        public bool IsIdentity => !Rotates && !Scales && !Translates;
+
         public bool Rotates => transformAngle != 0;
         public bool Scales => transformScale != 1;
         public bool Translates => transform != Affine2.Identity;
@@ -97,5 +99,13 @@ namespace StorybrewCommon.Storyboarding
 
         public Vector2 ApplyToScale(Vector2 value)
             => value * transformScale;
+    }
+
+    public class TransformException : Exception
+    {
+        internal TransformException(string message) : base(message)
+        {
+
+        }
     }
 }

--- a/common/Storyboarding/StoryboardTransform.cs
+++ b/common/Storyboarding/StoryboardTransform.cs
@@ -7,7 +7,9 @@ namespace StorybrewCommon.Storyboarding
 {
     public class StoryboardTransform
     {
-        public readonly static StoryboardTransform Identity = new StoryboardTransform(null, Vector2.Zero, Vector2.Zero, 0, 1, Vector2.Zero, 0, 1);
+        public readonly static StoryboardTransform Identity = new StoryboardTransform(null, Vector2.Zero, Vector2.Zero, 0, 1
+            //, Vector2.Zero, 0, 1
+            );
 
         private readonly Affine2 transform;
         private readonly Affine2 inverseTransform;
@@ -18,8 +20,9 @@ namespace StorybrewCommon.Storyboarding
         public bool Scales => transformScale != 1;
 
         public StoryboardTransform(StoryboardTransform parent,
-            Vector2 origin, Vector2 position, double rotation, float scale,
-            Vector2 placementPosition, double placementRotation, float placementScale)
+            Vector2 origin, Vector2 position, double rotation, float scale
+            //,Vector2 placementPosition, double placementRotation, float placementScale
+            )
         {
             transform = parent?.transform ?? Affine2.Identity;
             inverseTransform = parent?.inverseTransform ?? Affine2.Identity;
@@ -39,21 +42,21 @@ namespace StorybrewCommon.Storyboarding
                 inverseTransform.ScaleInverse(1 / scale, 1 / scale);
             }
 
-            if (placementPosition != Vector2.Zero)
-            {
-                transform.Translate(placementPosition.X, placementPosition.Y);
-                inverseTransform.TranslateInverse(-placementPosition.X, -placementPosition.Y);
-            }
-            if (placementRotation != 0)
-            {
-                transform.Rotate((float)placementRotation);
-                inverseTransform.RotateInverse(-(float)placementRotation);
-            }
-            if (placementScale != 1)
-            {
-                transform.Scale(placementScale, placementScale);
-                inverseTransform.ScaleInverse(1 / placementScale, 1 / placementScale);
-            }
+            //if (placementPosition != Vector2.Zero)
+            //{
+            //    transform.Translate(placementPosition.X, placementPosition.Y);
+            //    inverseTransform.TranslateInverse(-placementPosition.X, -placementPosition.Y);
+            //}
+            //if (placementRotation != 0)
+            //{
+            //    transform.Rotate((float)placementRotation);
+            //    inverseTransform.RotateInverse(-(float)placementRotation);
+            //}
+            //if (placementScale != 1)
+            //{
+            //    transform.Scale(placementScale, placementScale);
+            //    inverseTransform.ScaleInverse(1 / placementScale, 1 / placementScale);
+            //}
 
             if (origin != Vector2.Zero)
             {
@@ -61,7 +64,9 @@ namespace StorybrewCommon.Storyboarding
                 inverseTransform.TranslateInverse(origin.X, origin.Y);
             }
 
-            transformScale = (parent?.transformScale ?? 1) * scale * placementScale;
+            transformScale = (parent?.transformScale ?? 1) * scale
+                //* placementScale
+                ;
 
             
             // https://math.stackexchange.com/questions/13150/extracting-rotation-scale-values-from-2d-transformation-matrix/13165#13165

--- a/common/Storyboarding/StoryboardTransform.cs
+++ b/common/Storyboarding/StoryboardTransform.cs
@@ -14,6 +14,9 @@ namespace StorybrewCommon.Storyboarding
         private readonly float transformScale;
         private readonly double transformAngle;
 
+        public bool Rotates => transformAngle != 0;
+        public bool Scales => transformScale != 1;
+
         public StoryboardTransform(StoryboardTransform parent,
             Vector2 origin, Vector2 position, double rotation, float scale,
             Vector2 placementPosition, double placementRotation, float placementScale)
@@ -60,6 +63,7 @@ namespace StorybrewCommon.Storyboarding
 
             transformScale = (parent?.transformScale ?? 1) * scale * placementScale;
 
+            
             // https://math.stackexchange.com/questions/13150/extracting-rotation-scale-values-from-2d-transformation-matrix/13165#13165
             transformAngle = Math.Atan2(-transform.M21, transform.M11); // OR Math.Atan2(-transform.M22, transform.M12);
         }

--- a/common/Storyboarding/StoryboardTransform.cs
+++ b/common/Storyboarding/StoryboardTransform.cs
@@ -18,6 +18,7 @@ namespace StorybrewCommon.Storyboarding
 
         public bool Rotates => transformAngle != 0;
         public bool Scales => transformScale != 1;
+        public bool Translates => transform != Affine2.Identity;
 
         public StoryboardTransform(StoryboardTransform parent,
             Vector2 origin, Vector2 position, double rotation, float scale

--- a/editor/ScreenLayers/ProjectMenu.cs
+++ b/editor/ScreenLayers/ProjectMenu.cs
@@ -750,13 +750,10 @@ namespace StorybrewEditor.ScreenLayers
 
         private void effectConfigUi_OnResetPlacement(StoryboardSegment segment)
         {
-            var editorSegment = segment.AsEditorSegment();
-            editorSegment.PlacementPosition = Vector2.Zero;
-            editorSegment.PlacementRotation = 0f;
-            editorSegment.PlacementScale = 1f;
-
-            placementUi.Displayed = true;
             placementUi.Segment = segment;
+            placementUi.ResetState();
+            
+            placementUi.Displayed = true;
         }
 
         #region IDisposable Support

--- a/editor/Storyboarding/EditorOsbSprite.cs
+++ b/editor/Storyboarding/EditorOsbSprite.cs
@@ -3,6 +3,7 @@ using BrewLib.Graphics.Cameras;
 using BrewLib.Graphics.Renderers;
 using BrewLib.Graphics.Textures;
 using BrewLib.Util;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 using OpenTK;
 using OpenTK.Graphics;
 using StorybrewCommon.Mapset;
@@ -78,13 +79,11 @@ namespace StorybrewEditor.Storyboarding
 
             if (transform != null)
             {
-                if (sprite.HasMoveXYCommands)
-                    position = transform.ApplyToPositionXY(position); 
-                else position = transform.ApplyToPosition(position);
-                if (sprite.HasRotateCommands)
+                position = transform.ApplyToPosition(position); 
+                
+                if (!sprite.LockRotationOnTransform)
                     rotation = transform.ApplyToRotation(rotation);
-                if (sprite.HasScalingCommands)
-                    scale = transform.ApplyToScale(scale);
+                scale = transform.ApplyToScale(scale);
             }
 
             if (frameStats != null)

--- a/editor/Storyboarding/EditorStoryboardLayer.cs
+++ b/editor/Storyboarding/EditorStoryboardLayer.cs
@@ -6,6 +6,7 @@ using StorybrewCommon.Storyboarding;
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 
 namespace StorybrewEditor.Storyboarding
 {
@@ -180,6 +181,24 @@ namespace StorybrewEditor.Storyboarding
             DiffSpecific = other.DiffSpecific;
             OsbLayer = other.OsbLayer;
             Visible = other.Visible;
+
+            CopyTransforms(this, other);
+        }
+
+        void CopyTransforms(StoryboardSegment to, StoryboardSegment from)
+        {
+            to.Position = from.Position;
+            to.Rotation = from.Rotation;
+            to.Scale = from.Scale;
+
+            //in theory this is supposed to not be set
+            if (!from.NamedSegments.Any()) return;
+
+            foreach (StoryboardSegment fromSegment in from.NamedSegments)
+            {
+                CopyTransforms(to.GetSegment(fromSegment.Identifier), fromSegment);
+            }
+
         }
 
         public int CompareTo(EditorStoryboardLayer other)

--- a/editor/Storyboarding/EditorStoryboardLayer.cs
+++ b/editor/Storyboarding/EditorStoryboardLayer.cs
@@ -150,7 +150,7 @@ namespace StorybrewEditor.Storyboarding
             if (!Visible)
                 return;
 
-            segment.Draw(drawContext, camera, bounds, opacity, null, Effect.Project, frameStats);
+            segment.Draw(drawContext, camera, bounds, opacity, this.BuildCompleteParentTransform(), Effect.Project, frameStats);
         }
 
         public void PostProcess()
@@ -169,7 +169,7 @@ namespace StorybrewEditor.Storyboarding
         }
 
         public void WriteOsb(TextWriter writer, ExportSettings exportSettings)
-            => WriteOsb(writer, exportSettings, osbLayer, null);
+            => WriteOsb(writer, exportSettings, osbLayer, InternalSegment.BuildCompleteParentTransform());
 
         public override void WriteOsb(TextWriter writer, ExportSettings exportSettings, OsbLayer layer, StoryboardTransform transform) 
             => segment.WriteOsb(writer, exportSettings, osbLayer, transform);
@@ -187,6 +187,7 @@ namespace StorybrewEditor.Storyboarding
 
         void CopyTransforms(StoryboardSegment to, StoryboardSegment from)
         {
+            
             to.Position = from.Position;
             to.Rotation = from.Rotation;
             to.Scale = from.Scale;

--- a/editor/Storyboarding/EditorStoryboardSegment.cs
+++ b/editor/Storyboarding/EditorStoryboardSegment.cs
@@ -23,7 +23,7 @@ namespace StorybrewEditor.Storyboarding
         private double endTime;
         public override double EndTime => endTime;
 
-        public override Vector2 Origin { get; set; }
+        public override Vector2 Origin { get; set; } = Vector2.Zero;
         public override Vector2 Position { get; set; }
         public override double Rotation { get; set; }
         public override double Scale { get; set; } = 1f;

--- a/editor/Storyboarding/EditorStoryboardSegment.cs
+++ b/editor/Storyboarding/EditorStoryboardSegment.cs
@@ -237,11 +237,11 @@ namespace StorybrewEditor.Storyboarding
             displayableBuckets = null;
         }
 
-        public override void WriteOsb(TextWriter writer, ExportSettings exportSettings, OsbLayer osbLayer, StoryboardTransform transform)
+        public override void WriteOsb(TextWriter writer, ExportSettings exportSettings, OsbLayer osbLayer, StoryboardTransform localTransform)
         {
-            var localTransform = this.BuildTransform(transform);
+            StoryboardTransform thisTransform = this.BuildTransform(localTransform);
             foreach (var sbo in storyboardObjects)
-                sbo.WriteOsb(writer, exportSettings, osbLayer, localTransform);
+                sbo.WriteOsb(writer, exportSettings, osbLayer, thisTransform);
         }
 
         public int CalculateSize(OsbLayer osbLayer)

--- a/editor/Storyboarding/Project.cs
+++ b/editor/Storyboarding/Project.cs
@@ -687,7 +687,7 @@ namespace StorybrewEditor.Storyboarding
                 // Write each effect
                 foreach (var effect in effects)
                 {
-                    WriteTiny(effect, directoryWriter);
+                    WriteEffectTiny(effect, directoryWriter);
                 }
 
                 directoryWriter.Commit(checkPaths: true);
@@ -824,8 +824,6 @@ namespace StorybrewEditor.Storyboarding
             TinyArray potentialTokens = currentToken.Value<TinyArray>("Children");
             if (potentialTokens == null || potentialTokens.Count == 0) return;
 
-            //Dictionary<string, TinyToken> tokens = potentialTokens
-            //                                            .ToDictionary((tiny) => tiny.Value<string>("Name"));
 
             foreach (TinyToken token in potentialTokens)
             {
@@ -841,7 +839,7 @@ namespace StorybrewEditor.Storyboarding
         /// </summary>
         /// <param name="effect"></param>
         /// <param name="directoryWriter"></param>
-        void WriteTiny(Effect effect, SafeDirectoryWriter directoryWriter)
+        void WriteEffectTiny(Effect effect, SafeDirectoryWriter directoryWriter)
         {
             var effectRoot = new TinyObject
                     {
@@ -882,7 +880,6 @@ namespace StorybrewEditor.Storyboarding
 
             foreach (var layer in LayerManager.Layers.Where(l => l.Effect == effect))
             {
-                var childTinyObject = GetChildSegmentTiny(layer);
                 //Debug.Assert(childTinyObject != null);
                 var layerRoot =  GetLayerTiny(layer);
 

--- a/editor/Storyboarding/Project.cs
+++ b/editor/Storyboarding/Project.cs
@@ -4,6 +4,7 @@ using BrewLib.Graphics;
 using BrewLib.Graphics.Cameras;
 using BrewLib.Graphics.Textures;
 using BrewLib.Util;
+using ManagedBass;
 using OpenTK;
 using StorybrewCommon.Scripting;
 using StorybrewCommon.Storyboarding;
@@ -665,6 +666,8 @@ namespace StorybrewEditor.Storyboarding
                     indexRoot.Write(indexPath);
                 }
 
+                Debug.WriteLine("Index root saved!");
+
                 // Write user specific data
                 {
                     var userRoot = new TinyObject
@@ -680,60 +683,11 @@ namespace StorybrewEditor.Storyboarding
                     userRoot.Write(userPath);
                 }
 
+                Debug.WriteLine("User data saved!");
                 // Write each effect
                 foreach (var effect in effects)
                 {
-                    var effectRoot = new TinyObject
-                    {
-                        { "FormatVersion", Version },
-                        { "Name", effect.Name },
-                        { "Script", effect.BaseName },
-                        { "Multithreaded", effect.Multithreaded },
-                    };
-
-                    var configRoot = new TinyObject();
-                    effectRoot.Add("Config", configRoot);
-
-                    foreach (var field in effect.Config.SortedFields)
-                    {
-                        var fieldRoot = new TinyObject
-                        {
-                            { "Type", field.Type.FullName },
-                            { "Value", ObjectSerializer.ToString(field.Type, field.Value)},
-                        };
-                        if (field.DisplayName != field.Name)
-                            fieldRoot.Add("DisplayName", field.DisplayName);
-                        if (!string.IsNullOrWhiteSpace(field.BeginsGroup))
-                            fieldRoot.Add("BeginsGroup", field.BeginsGroup);
-                        configRoot.Add(field.Name, fieldRoot);
-
-                        if ((field.AllowedValues?.Length ?? 0) > 0)
-                        {
-                            var allowedValuesRoot = new TinyObject();
-                            fieldRoot.Add("AllowedValues", allowedValuesRoot);
-
-                            foreach (var allowedValue in field.AllowedValues)
-                                allowedValuesRoot.Add(allowedValue.Name, ObjectSerializer.ToString(field.Type, allowedValue.Value));
-                        }
-                    }
-
-                    var layersRoot = new TinyObject();
-                    effectRoot.Add("Layers", layersRoot);
-
-                    foreach (var layer in LayerManager.Layers.Where(l => l.Effect == effect))
-                    {
-                        var layerRoot = new TinyObject
-                        {
-                            { "Name", layer.Identifier },
-                            { "OsbLayer", layer.OsbLayer },
-                            { "DiffSpecific", layer.DiffSpecific },
-                            { "Visible", layer.Visible },
-                        };
-                        layersRoot.Add(layer.Guid.ToString("N"), layerRoot);
-                    }
-
-                    var effectPath = directoryWriter.GetPath("effect." + effect.Guid.ToString("N") + ".yaml");
-                    effectRoot.Write(effectPath);
+                    WriteTiny(effect, directoryWriter);
                 }
 
                 directoryWriter.Commit(checkPaths: true);
@@ -818,13 +772,21 @@ namespace StorybrewEditor.Storyboarding
                         var layerEffect = effect;
                         var layerGuid = layerProperty.Key;
                         var layerRoot = layerProperty.Value;
-                        layerInserters.Add(layerGuid, () => layerEffect.AddPlaceholder(new EditorStoryboardLayer(layerRoot.Value<string>("Name"), layerEffect)
+
+                        var transformRoot = layerRoot.Value<TinyObject>("Transform");
+                        EditorStoryboardLayer placeholderLayer = null;
+                        layerInserters.Add(layerGuid, () => layerEffect.AddPlaceholder(placeholderLayer = new EditorStoryboardLayer(layerRoot.Value<string>("Name"), layerEffect)
                         {
                             Guid = Guid.Parse(layerGuid),
                             OsbLayer = layerRoot.Value<OsbLayer>("OsbLayer"),
                             DiffSpecific = layerRoot.Value<bool>("DiffSpecific"),
                             Visible = layerRoot.Value<bool>("Visible"),
+                            Position = FromString(transformRoot.Value<string>("Offset")),
+                            Rotation = transformRoot.Value<float>("Rotation"),
+                            Scale = transformRoot.Value<float>("Scale"),
                         }));
+
+                        
                     }
                 }
 
@@ -847,6 +809,113 @@ namespace StorybrewEditor.Storyboarding
                     insertLayer();
                 }
             }
+        }
+
+        /// <summary>
+        /// Writes a tiny object for an effect to a file.
+        /// </summary>
+        /// <param name="effect"></param>
+        /// <param name="directoryWriter"></param>
+        void WriteTiny(Effect effect, SafeDirectoryWriter directoryWriter)
+        {
+            var effectRoot = new TinyObject
+                    {
+                        { "FormatVersion", Version },
+                        { "Name", effect.Name },
+                        { "Script", effect.BaseName },
+                        { "Multithreaded", effect.Multithreaded },
+                    };
+
+            var configRoot = new TinyObject();
+            effectRoot.Add("Config", configRoot);
+
+            foreach (var field in effect.Config.SortedFields)
+            {
+                var fieldRoot = new TinyObject
+                        {
+                            { "Type", field.Type.FullName },
+                            { "Value", ObjectSerializer.ToString(field.Type, field.Value)},
+                        };
+                if (field.DisplayName != field.Name)
+                    fieldRoot.Add("DisplayName", field.DisplayName);
+                if (!string.IsNullOrWhiteSpace(field.BeginsGroup))
+                    fieldRoot.Add("BeginsGroup", field.BeginsGroup);
+                configRoot.Add(field.Name, fieldRoot);
+
+                if ((field.AllowedValues?.Length ?? 0) > 0)
+                {
+                    var allowedValuesRoot = new TinyObject();
+                    fieldRoot.Add("AllowedValues", allowedValuesRoot);
+
+                    foreach (var allowedValue in field.AllowedValues)
+                        allowedValuesRoot.Add(allowedValue.Name, ObjectSerializer.ToString(field.Type, allowedValue.Value));
+                }
+            }
+
+            var layersRoot = new TinyObject();
+            effectRoot.Add("Layers", layersRoot);
+
+            foreach (var layer in LayerManager.Layers.Where(l => l.Effect == effect))
+            {
+                var childTinyObject = GetChildSegmentTiny(layer);
+                //Debug.Assert(childTinyObject != null);
+                var layerRoot =  GetLayerTiny(layer);
+
+                layersRoot.Add(layer.Guid.ToString("N"), layerRoot);
+            }
+
+            var effectPath = directoryWriter.GetPath("effect." + effect.Guid.ToString("N") + ".yaml");
+            effectRoot.Write(effectPath);
+
+        }
+
+        TinyObject GetLayerTiny(EditorStoryboardLayer layer)
+        {
+            return new TinyObject
+                        {
+                            { "Name", layer.Identifier },
+                            { "OsbLayer", layer.OsbLayer },
+                            { "DiffSpecific", layer.DiffSpecific },
+                            { "Visible", layer.Visible },
+                            {"Transform", GetChildSegmentTiny(layer) ?? new TinyObject() }
+                        };
+
+        }
+        TinyObject GetChildSegmentTiny(StoryboardSegment segment)
+        {
+
+            List<TinyObject> children = new List<TinyObject>();
+            foreach (StoryboardSegment child in segment.NamedSegments)
+            {
+                children.Add(GetChildSegmentTiny(child));
+            }
+            return 
+            new TinyObject
+            {
+                {"Name", segment.Identifier },
+                {"Offset", segment.Position.ToString() },
+                {"Rotation", segment.Rotation },
+                {"Scale", segment.Scale },
+                {"Children", children}
+            };
+        }
+
+
+        Vector2 FromString(string value)
+        {
+            string[] spl = value.Split(',', StringSplitOptions.TrimEntries);
+            foreach (string s in spl) Debug.WriteLine(s);
+
+            bool leftNegative, rightNegative;
+            
+            //i had to do it this way because Single.Parse was getting mad at me
+            string leftValue = spl[0].Substring((leftNegative = (spl[0][1] == '-')) ? 2 : 1, spl[0].Length - (leftNegative ? 2 : 1));
+            string rightValue = spl[1].Substring((rightNegative = spl[1][0] == '-') ? 1 : 0, spl[1].Length - (rightNegative ? 2 : 1));
+
+            Vector2 res = new Vector2((leftNegative ? -1 : 1) * float.Parse(leftValue, System.Globalization.NumberStyles.AllowDecimalPoint), (rightNegative ? -1 : 1) * float.Parse(rightValue, System.Globalization.NumberStyles.AllowDecimalPoint));
+
+            Debug.WriteLine(res);
+            return res;    
         }
 
         public static Project Create(string projectFolderName, string mapsetPath, bool withCommonScripts, ResourceContainer resourceContainer)

--- a/editor/Storyboarding/Project.cs
+++ b/editor/Storyboarding/Project.cs
@@ -775,16 +775,20 @@ namespace StorybrewEditor.Storyboarding
 
                         var transformRoot = layerRoot.Value<TinyObject>("Transform");
                         EditorStoryboardLayer placeholderLayer = null;
-                        layerInserters.Add(layerGuid, () => layerEffect.AddPlaceholder(placeholderLayer = new EditorStoryboardLayer(layerRoot.Value<string>("Name"), layerEffect)
+                        layerInserters.Add(layerGuid, () =>
                         {
-                            Guid = Guid.Parse(layerGuid),
-                            OsbLayer = layerRoot.Value<OsbLayer>("OsbLayer"),
-                            DiffSpecific = layerRoot.Value<bool>("DiffSpecific"),
-                            Visible = layerRoot.Value<bool>("Visible"),
-                            Position = FromString(transformRoot.Value<string>("Offset")),
-                            Rotation = transformRoot.Value<float>("Rotation"),
-                            Scale = transformRoot.Value<float>("Scale"),
-                        }));
+                            layerEffect.AddPlaceholder(placeholderLayer = new EditorStoryboardLayer(layerRoot.Value<string>("Name"), layerEffect)
+                            {
+                                Guid = Guid.Parse(layerGuid),
+                                OsbLayer = layerRoot.Value<OsbLayer>("OsbLayer"),
+                                DiffSpecific = layerRoot.Value<bool>("DiffSpecific"),
+                                Visible = layerRoot.Value<bool>("Visible")
+                            });
+
+                            Cascade(placeholderLayer, transformRoot);
+                        }
+
+                        );
 
                         
                     }
@@ -809,6 +813,27 @@ namespace StorybrewEditor.Storyboarding
                     insertLayer();
                 }
             }
+        }
+
+        void Cascade(StoryboardSegment segment, TinyObject currentToken)
+        {
+            segment.Position = VectorFromString(currentToken.Value<string>("Offset"));
+            segment.Rotation = currentToken.Value<float>("Rotation");
+            segment.Scale = currentToken.Value<float>("Scale");
+
+            TinyArray potentialTokens = currentToken.Value<TinyArray>("Children");
+            if (potentialTokens == null || potentialTokens.Count == 0) return;
+
+            //Dictionary<string, TinyToken> tokens = potentialTokens
+            //                                            .ToDictionary((tiny) => tiny.Value<string>("Name"));
+
+            foreach (TinyToken token in potentialTokens)
+            {
+                TinyObject obj = (TinyObject)token;
+                StoryboardSegment nextSegment = segment.GetSegment(obj.Value<string>("Name"));
+                Cascade(nextSegment, obj);
+            }
+            
         }
 
         /// <summary>
@@ -901,7 +926,7 @@ namespace StorybrewEditor.Storyboarding
         }
 
 
-        Vector2 FromString(string value)
+        Vector2 VectorFromString(string value)
         {
             string[] spl = value.Split(',', StringSplitOptions.TrimEntries);
             foreach (string s in spl) Debug.WriteLine(s);

--- a/editor/Storyboarding/StoryboardSegmentExtensions.cs
+++ b/editor/Storyboarding/StoryboardSegmentExtensions.cs
@@ -21,10 +21,13 @@ namespace StorybrewEditor.Storyboarding
         {
             var editorSegment = segment.AsEditorSegment();
             return new StoryboardTransform(parentTransform,
-                segment.Origin, segment.Position, segment.Rotation, (float)segment.Scale,
-                editorSegment.PlacementPosition, editorSegment.PlacementRotation, (float)editorSegment.PlacementScale);
+                segment.Origin, segment.Position, segment.Rotation, (float)segment.Scale);
+                //,
+                //editorSegment.PlacementPosition, editorSegment.PlacementRotation, (float)editorSegment.PlacementScale);
         }
         public static StoryboardTransform BuildTransformWithoutPlacement(this StoryboardSegment segment, StoryboardTransform parentTransform)
-            => new StoryboardTransform(parentTransform, segment.Origin, segment.Position, segment.Rotation, (float)segment.Scale, Vector2.Zero, 0, 1);
+            => new StoryboardTransform(parentTransform, segment.Origin, segment.Position, segment.Rotation, (float)segment.Scale
+                //, Vector2.Zero, 0, 1
+                );
     }
 }

--- a/editor/Storyboarding/StoryboardSegmentExtensions.cs
+++ b/editor/Storyboarding/StoryboardSegmentExtensions.cs
@@ -25,9 +25,6 @@ namespace StorybrewEditor.Storyboarding
                 //,
                 //editorSegment.PlacementPosition, editorSegment.PlacementRotation, (float)editorSegment.PlacementScale);
         }
-        public static StoryboardTransform BuildTransformWithoutPlacement(this StoryboardSegment segment, StoryboardTransform parentTransform)
-            => new StoryboardTransform(parentTransform, segment.Origin, segment.Position, segment.Rotation, (float)segment.Scale
-                //, Vector2.Zero, 0, 1
-                );
+
     }
 }

--- a/editor/UserInterface/Components/EffectConfigUi.cs
+++ b/editor/UserInterface/Components/EffectConfigUi.cs
@@ -212,7 +212,7 @@ namespace StorybrewEditor.UserInterface.Components
             configFieldsLayout.Add(new Label(Manager)
             {
                 StyleName = "listItem",
-                Text = "Left Click: Move\nShift + Left Click: Scale\nCTRL + Left Click: Rotate",
+                Text = "W: Move\nE: Scale\nR: Rotate",
                 AnchorFrom = BoxAlignment.Centre,
                 AnchorTo = BoxAlignment.Centre,
             });

--- a/editor/UserInterface/Components/EffectConfigUi.cs
+++ b/editor/UserInterface/Components/EffectConfigUi.cs
@@ -212,7 +212,7 @@ namespace StorybrewEditor.UserInterface.Components
             configFieldsLayout.Add(new Label(Manager)
             {
                 StyleName = "listItem",
-                Text = "W: Move\nE: Scale\nR: Rotate",
+                Text = "- W: Move\n- E: Scale\n- R: Rotate\n- CTRL + Z: Undo\n- CTRL + Shift + Z OR CTRL + Y: Redo",
                 AnchorFrom = BoxAlignment.Centre,
                 AnchorTo = BoxAlignment.Centre,
             });

--- a/editor/UserInterface/Components/EffectConfigUi.cs
+++ b/editor/UserInterface/Components/EffectConfigUi.cs
@@ -208,6 +208,14 @@ namespace StorybrewEditor.UserInterface.Components
                 AnchorFrom = BoxAlignment.Centre,
                 AnchorTo = BoxAlignment.Centre,
             });
+
+            configFieldsLayout.Add(new Label(Manager)
+            {
+                StyleName = "listItem",
+                Text = "Left Click: Move\nShift + Left Click: Scale\nCTRL + Left Click: Rotate",
+                AnchorFrom = BoxAlignment.Centre,
+                AnchorTo = BoxAlignment.Centre,
+            });
             foreach (var layer in effect.Project.LayerManager.Layers.Where(l => l.Effect == effect))
                 buildSegmentEditor(layer);
         }
@@ -228,7 +236,7 @@ namespace StorybrewEditor.UserInterface.Components
                     {
                         StyleName = "icon",
                         Icon = IconFont.Arrows,
-                        Tooltip = "Move",
+                        Tooltip = "Edit Transform",
                         AnchorFrom = BoxAlignment.Centre,
                         AnchorTo = BoxAlignment.Centre,
                         CanGrow = false,
@@ -239,7 +247,7 @@ namespace StorybrewEditor.UserInterface.Components
                         Text = new string(' ', depth * 2) + (string.IsNullOrWhiteSpace(segment.Identifier) ? "(Unnamed)": segment.Identifier),
                         AnchorFrom = BoxAlignment.TopLeft,
                         AnchorTo = BoxAlignment.TopLeft,
-                        Tooltip = $"Segment {segment.Identifier}",
+                        Tooltip = $"Segment - {segment.Identifier}",
                     },
                 },
             });

--- a/editor/UserInterface/Components/EffectConfigUi.cs
+++ b/editor/UserInterface/Components/EffectConfigUi.cs
@@ -57,6 +57,7 @@ namespace StorybrewEditor.UserInterface.Components
         public event Action<StoryboardSegment> OnSegmentSelected;
 
         public event Action<StoryboardSegment> OnStartPlacement;
+       
         public event Action<StoryboardSegment> OnResetPlacement;
         
         public EffectConfigUi(WidgetManager manager) : base(manager)
@@ -212,7 +213,7 @@ namespace StorybrewEditor.UserInterface.Components
             configFieldsLayout.Add(new Label(Manager)
             {
                 StyleName = "listItem",
-                Text = "- W: Move\n- E: Scale\n- R: Rotate\n- CTRL + Z: Undo\n- CTRL + Shift + Z OR CTRL + Y: Redo",
+                Text = "- W: Move\n- E: Scale\n- R: Rotate\n- CTRL + Z: Undo\n- CTRL + Shift + Z OR CTRL + Y: Redo\n\nNOTE: Move X / Y Commands do not export properly at the moment.",
                 AnchorFrom = BoxAlignment.Centre,
                 AnchorTo = BoxAlignment.Centre,
             });
@@ -224,6 +225,7 @@ namespace StorybrewEditor.UserInterface.Components
         {
             Widget segmentWidget;
             Button editButton;
+            Button resetButton;
             configFieldsLayout.Add(segmentWidget = new LinearLayout(Manager)
             {
                 AnchorFrom = BoxAlignment.Centre,
@@ -237,6 +239,15 @@ namespace StorybrewEditor.UserInterface.Components
                         StyleName = "icon",
                         Icon = IconFont.Arrows,
                         Tooltip = "Edit Transform",
+                        AnchorFrom = BoxAlignment.Centre,
+                        AnchorTo = BoxAlignment.Centre,
+                        CanGrow = false,
+                    },
+                    resetButton = new Button(Manager)
+                    {
+                        StyleName = "icon",
+                        Icon = IconFont.Undo,
+                        Tooltip = "Reset Transform",
                         AnchorFrom = BoxAlignment.Centre,
                         AnchorTo = BoxAlignment.Centre,
                         CanGrow = false,
@@ -270,12 +281,16 @@ namespace StorybrewEditor.UserInterface.Components
                 handledClick = false;
             };
 
+            resetButton.OnClick += (sender, e) =>
+            {
+                OnResetPlacement?.Invoke(segment);
+            };
             editButton.OnClick += (sender, e) =>
             {
-                if (e == OpenTK.Input.MouseButton.Left)
-                    OnStartPlacement?.Invoke(segment);
-                else if (e == OpenTK.Input.MouseButton.Right)
-                    OnResetPlacement?.Invoke(segment);
+                //if (e == OpenTK.Input.MouseButton.Left)
+                OnStartPlacement?.Invoke(segment);
+                //else if (e == OpenTK.Input.MouseButton.Right)
+                //    OnResetPlacement?.Invoke(segment);
             };
 
             foreach (var childSegment in segment.NamedSegments)

--- a/editor/UserInterface/Components/PlacementUi.cs
+++ b/editor/UserInterface/Components/PlacementUi.cs
@@ -25,6 +25,12 @@ namespace StorybrewEditor.UserInterface.Components
             }
         }
 
+        /// <summary>
+        /// Actually, this wasn't even necessary. Since a segment can take care of its own position, rotation, and scale
+        /// it ended up being easier to just directly edit those values instead of monitoring the placement scale, rotation, and position.
+        /// </summary>
+        //private EditorStoryboardSegment editorSegment;
+
         public override Vector2 MinSize => placementDrawable?.MinSize ?? Vector2.Zero;
         public override Vector2 PreferredSize => placementDrawable?.PreferredSize ?? Vector2.Zero;
 
@@ -57,7 +63,8 @@ namespace StorybrewEditor.UserInterface.Components
         {
             if (e.Button == MouseButton.Left)
             {
-                dragStartPosition = new Vector2(e.Position.X, e.Position.Y);
+                //editorSegment = Segment.AsEditorSegment();
+                dragStartPosition = new Vector2(e.X, e.Y);
                 var keyboardState = Keyboard.GetState();
                 if (keyboardState.IsKeyDown(Key.ShiftLeft))
                     state = State.Scaling;
@@ -71,7 +78,7 @@ namespace StorybrewEditor.UserInterface.Components
         private void placementUi_onClickUp(WidgetEvent evt, MouseButtonEventArgs e)
         {
             state = State.Idle;
-            
+            //editorSegment = null;
         }
         private void placementUi_onClickMove(WidgetEvent evt, MouseMoveEventArgs e)
         {
@@ -80,35 +87,40 @@ namespace StorybrewEditor.UserInterface.Components
 
             Debug.Assert(e.XDelta != 0 || e.YDelta != 0);
 
-            var editorSegment = Segment.AsEditorSegment();
-            var dragEndPosition = dragStartPosition + new Vector2(e.XDelta, e.YDelta);
+            Vector2 mouseDelta = new Vector2(e.XDelta, e.YDelta);
+            var dragEndPosition = dragStartPosition + mouseDelta;
             var dragFrom = placementDrawable.ScreenToSegment(dragStartPosition);
             var dragTo = placementDrawable.ScreenToSegment(dragEndPosition);
 
+            var deltaSegment = dragTo - dragFrom;
             //Debug.Assert(dragFrom != dragTo);
 
             switch (state)
             {
                 case State.Moving:
-                    editorSegment.PlacementPosition += dragTo - dragFrom;
+                    Segment.Position += deltaSegment;
+                    //editorSegment.PlacementPosition += deltaSegment;
                     break;
                 case State.Scaling:
-                    var oldScale = editorSegment.PlacementScale;
-                    editorSegment.PlacementScale *= dragTo.Length / dragFrom.Length;
-                    if (editorSegment.PlacementScale == 0)
-                        editorSegment.PlacementScale = oldScale;
+                    var oldScale = Segment.Scale;
+                    //editorSegment.PlacementScale *= dragTo.Length / dragFrom.Length;
+                    Segment.Scale *= dragTo.Length / dragFrom.Length;
+                    if (Segment.Scale == 0)
+                    {
+                        //editorSegment.PlacementScale = oldScale;
+                        Segment.Scale = oldScale;
+                    }
                     break;
                 case State.Rotating:
                     var fromAngle = Math.Atan2(dragFrom.Y, dragFrom.X);
                     var toAngle = Math.Atan2(dragTo.Y, dragTo.X);
                     var angleDelta = toAngle - fromAngle;
-                    editorSegment.PlacementRotation += angleDelta;
+                    //editorSegment.PlacementRotation += angleDelta;
+                    Segment.Rotation += angleDelta;
                     break;
             }
             dragStartPosition = dragEndPosition;
-            Segment.Position = editorSegment.PlacementPosition;
-            Segment.Rotation = editorSegment.PlacementRotation;
-            Segment.Scale = editorSegment.PlacementScale;
+            
         }
 
         protected override void DrawBackground(DrawContext drawContext, float actualOpacity)

--- a/editor/UserInterface/Components/PlacementUi.cs
+++ b/editor/UserInterface/Components/PlacementUi.cs
@@ -56,9 +56,10 @@ namespace StorybrewEditor.UserInterface.Components
             
         }
 
-        
+        bool redoing = false;
 
         private readonly Stack<TransformInfo> UndoStack = new Stack<TransformInfo>();
+        private readonly Stack<TransformInfo> RedoStack = new Stack<TransformInfo>();
 
         private bool placementUi_OnKeyDown(WidgetEvent evt, KeyboardKeyEventArgs e)
         {
@@ -83,20 +84,53 @@ namespace StorybrewEditor.UserInterface.Components
                         return true;
                     }
                 case Key.Z:
-                    if (!e.IsRepeat && e.Control && UndoStack.Count != 0)
+                    if (!e.IsRepeat && e.Control)
                     {
-                        
-                        TransformInfo last = UndoStack.Pop();
-                        Segment.Position = last.Position;
-                        Segment.Rotation = last.Rotation;
-                        Segment.Scale = last.Scale;
+                        if (e.Shift && RedoStack.Count > 0)
+                        {
+                            RedoTransform();
+                            return true;
+                        }
+
+                        if (!e.Shift && UndoStack.Count > 0)
+                            UndoTransform();
                     }
                     return true;
 
+                case Key.Y:
+                    if (!e.IsRepeat && e.Control && RedoStack.Count > 0)
+                    {
+                        RedoTransform();
+                    }
+                    return true;
                 default: return false;
             }
         }
 
+        void ApplyTransform(TransformInfo info)
+        {
+            Segment.Position = info.Position;
+            Segment.Rotation = info.Rotation;
+            Segment.Scale = info.Scale;
+        }
+        void UndoTransform()
+        {
+            TransformInfo info = UndoStack.Pop();
+            ApplyTransform(info);
+
+            RedoStack.Push(info);
+            redoing = false;
+        }
+        void RedoTransform()
+        {
+            TransformInfo info = RedoStack.Pop();
+            if (!redoing) info = RedoStack.Pop();
+
+            ApplyTransform(info);
+
+            UndoStack.Push(info);
+            redoing = true;
+        }
 
         protected override void Dispose(bool disposing)
         {
@@ -132,11 +166,22 @@ namespace StorybrewEditor.UserInterface.Components
             }
             return false;
         }
+        private TransformInfo GetCurrentInfo()
+        {
+            return new TransformInfo()
+            {
+                Position = Segment.Position,
+                Rotation = Segment.Rotation,
+                Scale = Segment.Scale
+            };
+        }
 
+        
         private void LogChange()
         {
             if (UndoStack.Count > 0)
             {
+                //ensure value was unique compared to the one before it.
                 TransformInfo top = UndoStack.Peek();
                 switch (transformType)
                 {
@@ -156,21 +201,15 @@ namespace StorybrewEditor.UserInterface.Components
                         break;
                 }
             }
-            UndoStack.Push(new TransformInfo()
-            {
-                Position = Segment.Position,
-                Rotation = Segment.Rotation,
-                Scale = Segment.Scale
-            });
+            UndoStack.Push(GetCurrentInfo());
+
+            RedoStack.Clear();
             
         }
         private void placementUi_onClickUp(WidgetEvent evt, MouseButtonEventArgs e)
         {
             state = PlacementUIState.Idle;
-            
-            //editorSegment = null;
-            
-
+            RedoStack.Push(GetCurrentInfo());
         }
         private void placementUi_onClickMove(WidgetEvent evt, MouseMoveEventArgs e)
         {
@@ -245,6 +284,16 @@ namespace StorybrewEditor.UserInterface.Components
             internal Vector2 Position;
             internal double Rotation;
             internal double Scale;
+
+            public override bool Equals(object obj)
+            {
+                return obj is TransformInfo i && GetHashCode() == i.GetHashCode();
+            }
+
+            public override int GetHashCode()
+            {
+                return Position.GetHashCode() ^ Rotation.GetHashCode() ^ Scale.GetHashCode();
+            }
         }
     }
 }

--- a/editor/UserInterface/Components/PlacementUi.cs
+++ b/editor/UserInterface/Components/PlacementUi.cs
@@ -217,7 +217,8 @@ namespace StorybrewEditor.UserInterface.Components
                 return;
             
             Debug.Assert(e.XDelta != 0 || e.YDelta != 0);
-            mousePosition = new Vector2(e.X, e.Y);
+
+            mousePosition = placementDrawable.StoryboardToScreen(new Vector2(e.X, e.Y));
             Vector2 mouseDelta = new Vector2(e.XDelta, e.YDelta);
             var dragEndPosition = dragStartPosition + mouseDelta;
             var dragFrom = placementDrawable.ScreenToSegment(dragStartPosition);

--- a/editor/UserInterface/Components/PlacementUi.cs
+++ b/editor/UserInterface/Components/PlacementUi.cs
@@ -56,6 +56,19 @@ namespace StorybrewEditor.UserInterface.Components
             
         }
 
+        public void ResetState()
+        {
+            TransformInfo info = new TransformInfo()
+            {
+               Position = Vector2.Zero,
+               Rotation = 0,
+               Scale = 1
+            };
+
+            ApplyTransform(info);
+            UndoStack.Push(info);
+        }
+
         bool redoing = false;
 
         private readonly Stack<TransformInfo> UndoStack = new Stack<TransformInfo>();
@@ -80,7 +93,10 @@ namespace StorybrewEditor.UserInterface.Components
                 case Key.R:
                     {
                         if (!activeChanges)
+                        {
+                            rotationVector = Vector2.Zero;
                             transformType = PlacementUITransformType.Rotate;
+                        }
                         return true;
                     }
                 case Key.Z:
@@ -193,6 +209,7 @@ namespace StorybrewEditor.UserInterface.Components
                     case PlacementUITransformType.Rotate:
                         if (top.Rotation == Segment.Rotation)
                             return;
+                        
                         break;
 
                     case PlacementUITransformType.Scale:
@@ -267,8 +284,11 @@ namespace StorybrewEditor.UserInterface.Components
             if (placementDrawable.Segment != null)
                 placementDrawable.Draw(drawContext, Manager.Camera, Bounds, actualOpacity);
 
-            var renderer = DrawState.Prepare(drawContext.Get<LineRenderer>(), Manager.Camera, linesRenderStates);
-            renderer.Draw(new Vector3(placementDrawable.Center), new Vector3(placementDrawable.Center+ rotationVector), Color4.Yellow);
+            if (transformType == PlacementUITransformType.Rotate)
+            {
+                var renderer = DrawState.Prepare(drawContext.Get<LineRenderer>(), Manager.Camera, linesRenderStates);
+                renderer.Draw(new Vector3(placementDrawable.Center), new Vector3(placementDrawable.Center+ rotationVector), Color4.Yellow);
+            }
         }
 
         internal enum PlacementUIState

--- a/editor/UserInterface/Components/PlacementUi.cs
+++ b/editor/UserInterface/Components/PlacementUi.cs
@@ -247,7 +247,7 @@ namespace StorybrewEditor.UserInterface.Components
                     break;
                 case PlacementUITransformType.Rotate:
                     //calculate something here man idk
-                    rotationVector = placementDrawable.StoryboardToScreen(placementDrawable.Center) - mousePosition;
+                    rotationVector = mousePosition - placementDrawable.Center;
 
                     var norm_rotVec = rotationVector.Normalized();
                     //offsetVector.X - cos

--- a/editor/UserInterface/Components/PlacementUi.cs
+++ b/editor/UserInterface/Components/PlacementUi.cs
@@ -71,6 +71,7 @@ namespace StorybrewEditor.UserInterface.Components
         private void placementUi_onClickUp(WidgetEvent evt, MouseButtonEventArgs e)
         {
             state = State.Idle;
+            
         }
         private void placementUi_onClickMove(WidgetEvent evt, MouseMoveEventArgs e)
         {
@@ -105,6 +106,9 @@ namespace StorybrewEditor.UserInterface.Components
                     break;
             }
             dragStartPosition = dragEndPosition;
+            Segment.Position = editorSegment.PlacementPosition;
+            Segment.Rotation = editorSegment.PlacementRotation;
+            Segment.Scale = editorSegment.PlacementScale;
         }
 
         protected override void DrawBackground(DrawContext drawContext, float actualOpacity)

--- a/editor/UserInterface/Components/PlacementUi.cs
+++ b/editor/UserInterface/Components/PlacementUi.cs
@@ -1,12 +1,15 @@
 ﻿using BrewLib.Graphics;
+using BrewLib.Graphics.Renderers;
 using BrewLib.UserInterface;
 using BrewLib.Util;
 using OpenTK;
+using OpenTK.Graphics;
 using OpenTK.Input;
 using StorybrewCommon.Storyboarding;
 using StorybrewEditor.Storyboarding;
 using StorybrewEditor.UserInterface.Drawables;
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 
 namespace StorybrewEditor.UserInterface.Components
@@ -36,59 +39,146 @@ namespace StorybrewEditor.UserInterface.Components
 
         private PlacementDrawable placementDrawable;
 
-        internal PlacementUIState GetState() => state;
+        private readonly RenderStates linesRenderStates = new RenderStates();
+
+        internal PlacementUITransformType GetTransformType() => transformType;
+
+        private Vector2 mousePosition;
 
         public PlacementUi(WidgetManager manager) : base(manager)
         {
             placementDrawable = new PlacementDrawable(this);
 
+            OnKeyDown += placementUi_OnKeyDown;
             OnClickDown += placementUi_OnClickDown;
             OnClickUp += placementUi_onClickUp;
             OnClickMove += placementUi_onClickMove;
+            
         }
+
+        
+
+        private readonly Stack<TransformInfo> UndoStack = new Stack<TransformInfo>();
+
+        private bool placementUi_OnKeyDown(WidgetEvent evt, KeyboardKeyEventArgs e)
+        {
+            switch (e.Key)
+            {
+                case Key.W:
+                    {
+                        if (!activeChanges)
+                            transformType = PlacementUITransformType.Move;
+                        return true;
+                    }
+                case Key.E:
+                    {
+                        if (!activeChanges)
+                            transformType = PlacementUITransformType.Scale;
+                        return true;
+                    }
+                case Key.R:
+                    {
+                        if (!activeChanges)
+                            transformType = PlacementUITransformType.Rotate;
+                        return true;
+                    }
+                case Key.Z:
+                    if (!e.IsRepeat && e.Control && UndoStack.Count != 0)
+                    {
+                        
+                        TransformInfo last = UndoStack.Pop();
+                        Segment.Position = last.Position;
+                        Segment.Rotation = last.Rotation;
+                        Segment.Scale = last.Scale;
+                    }
+                    return true;
+
+                default: return false;
+            }
+        }
+
 
         protected override void Dispose(bool disposing)
         {
             base.Dispose(disposing);
             if (disposing)
             {
+                
                 OnClickDown -= placementUi_OnClickDown;
                 OnClickUp -= placementUi_onClickUp;
                 OnClickMove -= placementUi_onClickMove;
+                OnKeyDown -= placementUi_OnKeyDown;
             }
             placementDrawable = null;
         }
 
         private Vector2 dragStartPosition;
+
+        private bool activeChanges = false;
+        private Vector2 rotationVector;
         private PlacementUIState state = PlacementUIState.Idle;
+        private PlacementUITransformType transformType;
+
+        
         private bool placementUi_OnClickDown(WidgetEvent evt, MouseButtonEventArgs e)
         {
             if (e.Button == MouseButton.Left)
             {
                 //editorSegment = Segment.AsEditorSegment();
                 dragStartPosition = new Vector2(e.X, e.Y);
-                var keyboardState = Keyboard.GetState();
-                if (keyboardState.IsKeyDown(Key.ShiftLeft))
-                    state = PlacementUIState.Scaling;
-                else if (keyboardState.IsKeyDown(Key.ControlLeft))
-                    state = PlacementUIState.Rotating;
-                else state = PlacementUIState.Moving;
+                state = PlacementUIState.Doing;
+                LogChange();
                 return true;
             }
             return false;
         }
+
+        private void LogChange()
+        {
+            if (UndoStack.Count > 0)
+            {
+                TransformInfo top = UndoStack.Peek();
+                switch (transformType)
+                {
+                    case PlacementUITransformType.Move:
+                        if (top.Position == Segment.Position)
+                            return;
+                        break;
+
+                    case PlacementUITransformType.Rotate:
+                        if (top.Rotation == Segment.Rotation)
+                            return;
+                        break;
+
+                    case PlacementUITransformType.Scale:
+                        if (top.Scale == Segment.Scale) 
+                            return;
+                        break;
+                }
+            }
+            UndoStack.Push(new TransformInfo()
+            {
+                Position = Segment.Position,
+                Rotation = Segment.Rotation,
+                Scale = Segment.Scale
+            });
+            
+        }
         private void placementUi_onClickUp(WidgetEvent evt, MouseButtonEventArgs e)
         {
             state = PlacementUIState.Idle;
+            
             //editorSegment = null;
+            
+
         }
         private void placementUi_onClickMove(WidgetEvent evt, MouseMoveEventArgs e)
         {
             if (state == PlacementUIState.Idle)
                 return;
-
+            
             Debug.Assert(e.XDelta != 0 || e.YDelta != 0);
-
+            mousePosition = new Vector2(e.X, e.Y);
             Vector2 mouseDelta = new Vector2(e.XDelta, e.YDelta);
             var dragEndPosition = dragStartPosition + mouseDelta;
             var dragFrom = placementDrawable.ScreenToSegment(dragStartPosition);
@@ -97,28 +187,33 @@ namespace StorybrewEditor.UserInterface.Components
             var deltaSegment = dragTo - dragFrom;
             //Debug.Assert(dragFrom != dragTo);
 
-            switch (state)
+            switch (transformType)
             {
-                case PlacementUIState.Moving:
-                    Segment.Position += deltaSegment;
+                case PlacementUITransformType.Move:
+                    Segment.Position += mouseDelta;
                     //editorSegment.PlacementPosition += deltaSegment;
                     break;
-                case PlacementUIState.Scaling:
+                case PlacementUITransformType.Scale:
                     var oldScale = Segment.Scale;
                     //editorSegment.PlacementScale *= dragTo.Length / dragFrom.Length;
-                    Segment.Scale *= dragTo.Length / dragFrom.Length;
+                    float dScale = dragTo.Length / dragFrom.Length;
+                    Segment.Scale *= dScale;
+                    
                     if (Segment.Scale == 0)
                     {
                         //editorSegment.PlacementScale = oldScale;
                         Segment.Scale = oldScale;
                     }
+
                     break;
-                case PlacementUIState.Rotating:
-                    var fromAngle = Math.Atan2(dragFrom.Y, dragFrom.X);
-                    var toAngle = Math.Atan2(dragTo.Y, dragTo.X);
-                    var angleDelta = toAngle - fromAngle;
-                    //editorSegment.PlacementRotation += angleDelta;
-                    Segment.Rotation += angleDelta;
+                case PlacementUITransformType.Rotate:
+                    //calculate something here man idk
+                    rotationVector = placementDrawable.ScreenToSegment(mousePosition) - placementDrawable.Offset;
+                    rotationVector.Normalize();
+                    //offsetVector.X - cos
+                    //offsetVector.Y - sin
+                    Segment.Rotation = Math.Atan2(rotationVector.Y, rotationVector.X);
+                    
                     break;
             }
             dragStartPosition = dragEndPosition;
@@ -130,14 +225,26 @@ namespace StorybrewEditor.UserInterface.Components
             base.DrawBackground(drawContext, actualOpacity);
             if (placementDrawable.Segment != null)
                 placementDrawable.Draw(drawContext, Manager.Camera, Bounds, actualOpacity);
+
+            var renderer = DrawState.Prepare(drawContext.Get<LineRenderer>(), Manager.Camera, linesRenderStates);
+            renderer.Draw(new Vector3(Segment.Position), new Vector3(Segment.Position + rotationVector * 10), Color4.Yellow);
         }
 
         internal enum PlacementUIState
         {
-            Idle,
-            Moving,
-            Scaling,
-            Rotating,
+            Idle, Doing
+        }
+
+        internal enum PlacementUITransformType
+        {
+            Move, Scale, Rotate
+        }
+
+        private class TransformInfo
+        {
+            internal Vector2 Position;
+            internal double Rotation;
+            internal double Scale;
         }
     }
 }

--- a/editor/UserInterface/Components/PlacementUi.cs
+++ b/editor/UserInterface/Components/PlacementUi.cs
@@ -247,11 +247,12 @@ namespace StorybrewEditor.UserInterface.Components
                     break;
                 case PlacementUITransformType.Rotate:
                     //calculate something here man idk
-                    rotationVector = placementDrawable.ScreenToSegment(mousePosition) - placementDrawable.Offset;
-                    rotationVector.Normalize();
+                    rotationVector = placementDrawable.StoryboardToScreen(placementDrawable.Center) - mousePosition;
+
+                    var norm_rotVec = rotationVector.Normalized();
                     //offsetVector.X - cos
                     //offsetVector.Y - sin
-                    Segment.Rotation = Math.Atan2(rotationVector.Y, rotationVector.X);
+                    Segment.Rotation = Math.Atan2(norm_rotVec.Y, norm_rotVec.X);
                     
                     break;
             }
@@ -266,7 +267,7 @@ namespace StorybrewEditor.UserInterface.Components
                 placementDrawable.Draw(drawContext, Manager.Camera, Bounds, actualOpacity);
 
             var renderer = DrawState.Prepare(drawContext.Get<LineRenderer>(), Manager.Camera, linesRenderStates);
-            renderer.Draw(new Vector3(Segment.Position), new Vector3(Segment.Position + rotationVector * 10), Color4.Yellow);
+            renderer.Draw(new Vector3(placementDrawable.Center), new Vector3(placementDrawable.Center+ rotationVector), Color4.Yellow);
         }
 
         internal enum PlacementUIState

--- a/editor/UserInterface/Components/PlacementUi.cs
+++ b/editor/UserInterface/Components/PlacementUi.cs
@@ -36,9 +36,11 @@ namespace StorybrewEditor.UserInterface.Components
 
         private PlacementDrawable placementDrawable;
 
+        internal PlacementUIState GetState() => state;
+
         public PlacementUi(WidgetManager manager) : base(manager)
         {
-            placementDrawable = new PlacementDrawable();
+            placementDrawable = new PlacementDrawable(this);
 
             OnClickDown += placementUi_OnClickDown;
             OnClickUp += placementUi_onClickUp;
@@ -58,7 +60,7 @@ namespace StorybrewEditor.UserInterface.Components
         }
 
         private Vector2 dragStartPosition;
-        private State state = State.Idle;
+        private PlacementUIState state = PlacementUIState.Idle;
         private bool placementUi_OnClickDown(WidgetEvent evt, MouseButtonEventArgs e)
         {
             if (e.Button == MouseButton.Left)
@@ -67,22 +69,22 @@ namespace StorybrewEditor.UserInterface.Components
                 dragStartPosition = new Vector2(e.X, e.Y);
                 var keyboardState = Keyboard.GetState();
                 if (keyboardState.IsKeyDown(Key.ShiftLeft))
-                    state = State.Scaling;
+                    state = PlacementUIState.Scaling;
                 else if (keyboardState.IsKeyDown(Key.ControlLeft))
-                    state = State.Rotating;
-                else state = State.Moving;
+                    state = PlacementUIState.Rotating;
+                else state = PlacementUIState.Moving;
                 return true;
             }
             return false;
         }
         private void placementUi_onClickUp(WidgetEvent evt, MouseButtonEventArgs e)
         {
-            state = State.Idle;
+            state = PlacementUIState.Idle;
             //editorSegment = null;
         }
         private void placementUi_onClickMove(WidgetEvent evt, MouseMoveEventArgs e)
         {
-            if (state == State.Idle)
+            if (state == PlacementUIState.Idle)
                 return;
 
             Debug.Assert(e.XDelta != 0 || e.YDelta != 0);
@@ -97,11 +99,11 @@ namespace StorybrewEditor.UserInterface.Components
 
             switch (state)
             {
-                case State.Moving:
+                case PlacementUIState.Moving:
                     Segment.Position += deltaSegment;
                     //editorSegment.PlacementPosition += deltaSegment;
                     break;
-                case State.Scaling:
+                case PlacementUIState.Scaling:
                     var oldScale = Segment.Scale;
                     //editorSegment.PlacementScale *= dragTo.Length / dragFrom.Length;
                     Segment.Scale *= dragTo.Length / dragFrom.Length;
@@ -111,7 +113,7 @@ namespace StorybrewEditor.UserInterface.Components
                         Segment.Scale = oldScale;
                     }
                     break;
-                case State.Rotating:
+                case PlacementUIState.Rotating:
                     var fromAngle = Math.Atan2(dragFrom.Y, dragFrom.X);
                     var toAngle = Math.Atan2(dragTo.Y, dragTo.X);
                     var angleDelta = toAngle - fromAngle;
@@ -130,7 +132,7 @@ namespace StorybrewEditor.UserInterface.Components
                 placementDrawable.Draw(drawContext, Manager.Camera, Bounds, actualOpacity);
         }
 
-        private enum State
+        internal enum PlacementUIState
         {
             Idle,
             Moving,

--- a/editor/UserInterface/Drawables/PlacementDrawable.cs
+++ b/editor/UserInterface/Drawables/PlacementDrawable.cs
@@ -14,7 +14,7 @@ namespace StorybrewEditor.UserInterface.Drawables
         public Vector2 MinSize => Vector2.Zero;
         public Vector2 PreferredSize => new Vector2(854, 480);
 
-        public const float RingDistance = 240;
+        public const float RingDistance = 120;
 
         public StoryboardSegment Segment { get; set; }
         public StoryboardTransform ParentTransform { get; set; }
@@ -35,6 +35,13 @@ namespace StorybrewEditor.UserInterface.Drawables
             var bottom = StoryboardToScreen(transform.ApplyToPosition(Vector2.UnitY * 10000));
             var left = StoryboardToScreen(transform.ApplyToPosition(Vector2.UnitX * -10000));
             var right = StoryboardToScreen(transform.ApplyToPosition(Vector2.UnitX * 10000));
+
+            var positionOffset = PreferredSize * 0.5f;
+            center += positionOffset;
+            top += positionOffset;
+            bottom += positionOffset;
+            left += positionOffset;
+            right += positionOffset;
 
             var renderer = DrawState.Prepare(drawContext.Get<LineRenderer>(), camera, linesRenderStates);
             renderer.DrawSquare(new Vector3(bounds.Left, bounds.Top, 0), new Vector3(bounds.Right, bounds.Bottom, 0), Color4.DarkGray);

--- a/editor/UserInterface/Drawables/PlacementDrawable.cs
+++ b/editor/UserInterface/Drawables/PlacementDrawable.cs
@@ -26,8 +26,10 @@ namespace StorybrewEditor.UserInterface.Drawables
         private StoryboardTransform transform;
         private float scaleFactor;
         private Vector2 offset;
+        private Vector2 center;
 
         internal Vector2 Offset => offset;
+        internal Vector2 Center => center;
 
         private readonly PlacementUi ui;
 
@@ -41,7 +43,7 @@ namespace StorybrewEditor.UserInterface.Drawables
             transform = Segment.BuildTransform(ParentTransform);
             scaleFactor = bounds.Height / 480;
             offset = new Vector2(bounds.Left + bounds.Width * 0.5f - 320 * scaleFactor, bounds.Top + bounds.Height * 0.5f - 240 * scaleFactor);
-            var center = StoryboardToScreen(transform.ApplyToPosition(Vector2.Zero));
+            center = StoryboardToScreen(transform.ApplyToPosition(Vector2.Zero));
             var top = StoryboardToScreen(transform.ApplyToPosition(Vector2.UnitY * -10000));
             var bottom = StoryboardToScreen(transform.ApplyToPosition(Vector2.UnitY * 10000));
             var left = StoryboardToScreen(transform.ApplyToPosition(Vector2.UnitX * -10000));

--- a/editor/UserInterface/Drawables/PlacementDrawable.cs
+++ b/editor/UserInterface/Drawables/PlacementDrawable.cs
@@ -30,7 +30,6 @@ namespace StorybrewEditor.UserInterface.Drawables
             transform = Segment.BuildTransform(ParentTransform);
             scaleFactor = bounds.Height / 480;
             offset = new Vector2(bounds.Left + bounds.Width * 0.5f - 320 * scaleFactor, bounds.Top);
-
             var center = StoryboardToScreen(transform.ApplyToPosition(Vector2.Zero));
             var top = StoryboardToScreen(transform.ApplyToPosition(Vector2.UnitY * -10000));
             var bottom = StoryboardToScreen(transform.ApplyToPosition(Vector2.UnitY * 10000));

--- a/editor/UserInterface/Drawables/PlacementDrawable.cs
+++ b/editor/UserInterface/Drawables/PlacementDrawable.cs
@@ -42,7 +42,7 @@ namespace StorybrewEditor.UserInterface.Drawables
         {
             transform = Segment.BuildTransform(ParentTransform);
             scaleFactor = bounds.Height / 480;
-            offset = new Vector2(bounds.Left + bounds.Width * 0.5f - 320 * scaleFactor, bounds.Top + bounds.Height * 0.5f - 240 * scaleFactor);
+            offset = new Vector2(bounds.Left + bounds.Width*0.5f - 320 * scaleFactor, bounds.Top + bounds.Height*0.5f - 240 * scaleFactor);
             center = StoryboardToScreen(transform.ApplyToPosition(Vector2.Zero));
             var top = StoryboardToScreen(transform.ApplyToPosition(Vector2.UnitY * -10000));
             var bottom = StoryboardToScreen(transform.ApplyToPosition(Vector2.UnitY * 10000));
@@ -51,7 +51,11 @@ namespace StorybrewEditor.UserInterface.Drawables
 
             //var positionOffset = new Vector2(bounds.Width, bounds.Height)*0.5f;
             ////Debug.WriteLine(positionOffset);
-
+            //center += offset;
+            //top += offset;
+            //bottom += offset;
+            //left += offset;
+            //right += offset;
             //center += positionOffset;
             //top += positionOffset;
             //bottom += positionOffset;

--- a/editor/UserInterface/Drawables/PlacementDrawable.cs
+++ b/editor/UserInterface/Drawables/PlacementDrawable.cs
@@ -27,7 +27,7 @@ namespace StorybrewEditor.UserInterface.Drawables
         private float scaleFactor;
         private Vector2 offset;
 
-        private PlacementUi ui;
+        private readonly PlacementUi ui;
 
         internal PlacementDrawable(PlacementUi ui) : base()
         {

--- a/editor/UserInterface/Drawables/PlacementDrawable.cs
+++ b/editor/UserInterface/Drawables/PlacementDrawable.cs
@@ -6,6 +6,8 @@ using OpenTK;
 using OpenTK.Graphics;
 using StorybrewCommon.Storyboarding;
 using StorybrewEditor.Storyboarding;
+using StorybrewEditor.UserInterface.Components;
+using System.Diagnostics;
 
 namespace StorybrewEditor.UserInterface.Drawables
 {
@@ -25,6 +27,13 @@ namespace StorybrewEditor.UserInterface.Drawables
         private float scaleFactor;
         private Vector2 offset;
 
+        private PlacementUi ui;
+
+        internal PlacementDrawable(PlacementUi ui) : base()
+        {
+            this.ui = ui;
+        }
+
         public void Draw(DrawContext drawContext, Camera camera, Box2 bounds, float opacity = 1)
         {
             transform = Segment.BuildTransform(ParentTransform);
@@ -36,7 +45,9 @@ namespace StorybrewEditor.UserInterface.Drawables
             var left = StoryboardToScreen(transform.ApplyToPosition(Vector2.UnitX * -10000));
             var right = StoryboardToScreen(transform.ApplyToPosition(Vector2.UnitX * 10000));
 
-            var positionOffset = PreferredSize * 0.5f;
+            var positionOffset = new Vector2(bounds.Width, bounds.Height)*0.5f;
+            //Debug.WriteLine(positionOffset);
+
             center += positionOffset;
             top += positionOffset;
             bottom += positionOffset;
@@ -50,7 +61,19 @@ namespace StorybrewEditor.UserInterface.Drawables
             renderer.Draw(new Vector3(top + Vector2.One), new Vector3(bottom + Vector2.One), Color4.Black);
             renderer.Draw(new Vector3(left + Vector2.One), new Vector3(right + Vector2.One), Color4.Black);
 
-            renderer.DrawCircle(center, RingDistance, Color4.Blue);
+            Color4 DrawColor = Color4.Blue;
+            switch (ui.GetState())
+            {
+                case PlacementUi.PlacementUIState.Scaling:
+                    DrawColor = Color4.Green;
+                    break;
+                case PlacementUi.PlacementUIState.Rotating:
+                    DrawColor = Color4.Red;
+                    break;
+                default:break;
+            }
+           
+            renderer.DrawCircle(center, RingDistance, DrawColor);
             renderer.Draw(new Vector3(top), new Vector3(bottom), Color4.Blue);
             renderer.Draw(new Vector3(left), new Vector3(right), Color4.Blue);
         }

--- a/editor/UserInterface/Drawables/PlacementDrawable.cs
+++ b/editor/UserInterface/Drawables/PlacementDrawable.cs
@@ -42,12 +42,17 @@ namespace StorybrewEditor.UserInterface.Drawables
         {
             transform = Segment.BuildTransform(ParentTransform);
             scaleFactor = bounds.Height / 480;
-            offset = new Vector2(bounds.Left + bounds.Width*0.5f - 320 * scaleFactor, bounds.Top + bounds.Height*0.5f - 240 * scaleFactor);
+            offset = new Vector2(bounds.Width*0.5f - 427 * scaleFactor, bounds.Height*0.5f - 240 * scaleFactor);
             center = StoryboardToScreen(transform.ApplyToPosition(Vector2.Zero));
             var top = StoryboardToScreen(transform.ApplyToPosition(Vector2.UnitY * -10000));
             var bottom = StoryboardToScreen(transform.ApplyToPosition(Vector2.UnitY * 10000));
             var left = StoryboardToScreen(transform.ApplyToPosition(Vector2.UnitX * -10000));
             var right = StoryboardToScreen(transform.ApplyToPosition(Vector2.UnitX * 10000));
+            //center = transform.ApplyToPosition(Vector2.Zero);
+            //var top = transform.ApplyToPosition(Vector2.UnitY * -10000);
+            //var bottom = transform.ApplyToPosition(Vector2.UnitY * 10000);
+            //var left = transform.ApplyToPosition(Vector2.UnitX * -10000);
+            //var right = transform.ApplyToPosition(Vector2.UnitX * 10000);
 
             //var positionOffset = new Vector2(bounds.Width, bounds.Height)*0.5f;
             ////Debug.WriteLine(positionOffset);

--- a/editor/UserInterface/Drawables/PlacementDrawable.cs
+++ b/editor/UserInterface/Drawables/PlacementDrawable.cs
@@ -27,6 +27,8 @@ namespace StorybrewEditor.UserInterface.Drawables
         private float scaleFactor;
         private Vector2 offset;
 
+        internal Vector2 Offset => offset;
+
         private readonly PlacementUi ui;
 
         internal PlacementDrawable(PlacementUi ui) : base()
@@ -38,21 +40,21 @@ namespace StorybrewEditor.UserInterface.Drawables
         {
             transform = Segment.BuildTransform(ParentTransform);
             scaleFactor = bounds.Height / 480;
-            offset = new Vector2(bounds.Left + bounds.Width * 0.5f - 320 * scaleFactor, bounds.Top);
+            offset = new Vector2(bounds.Left + bounds.Width * 0.5f - 320 * scaleFactor, bounds.Top + bounds.Height * 0.5f - 240 * scaleFactor);
             var center = StoryboardToScreen(transform.ApplyToPosition(Vector2.Zero));
             var top = StoryboardToScreen(transform.ApplyToPosition(Vector2.UnitY * -10000));
             var bottom = StoryboardToScreen(transform.ApplyToPosition(Vector2.UnitY * 10000));
             var left = StoryboardToScreen(transform.ApplyToPosition(Vector2.UnitX * -10000));
             var right = StoryboardToScreen(transform.ApplyToPosition(Vector2.UnitX * 10000));
 
-            var positionOffset = new Vector2(bounds.Width, bounds.Height)*0.5f;
-            //Debug.WriteLine(positionOffset);
+            //var positionOffset = new Vector2(bounds.Width, bounds.Height)*0.5f;
+            ////Debug.WriteLine(positionOffset);
 
-            center += positionOffset;
-            top += positionOffset;
-            bottom += positionOffset;
-            left += positionOffset;
-            right += positionOffset;
+            //center += positionOffset;
+            //top += positionOffset;
+            //bottom += positionOffset;
+            //left += positionOffset;
+            //right += positionOffset;
 
             var renderer = DrawState.Prepare(drawContext.Get<LineRenderer>(), camera, linesRenderStates);
             renderer.DrawSquare(new Vector3(bounds.Left, bounds.Top, 0), new Vector3(bounds.Right, bounds.Bottom, 0), Color4.DarkGray);
@@ -62,17 +64,17 @@ namespace StorybrewEditor.UserInterface.Drawables
             renderer.Draw(new Vector3(left + Vector2.One), new Vector3(right + Vector2.One), Color4.Black);
 
             Color4 DrawColor = Color4.Blue;
-            switch (ui.GetState())
+            switch (ui.GetTransformType())
             {
-                case PlacementUi.PlacementUIState.Scaling:
+                case PlacementUi.PlacementUITransformType.Scale:
                     DrawColor = Color4.Green;
                     break;
-                case PlacementUi.PlacementUIState.Rotating:
+                case PlacementUi.PlacementUITransformType.Rotate:
                     DrawColor = Color4.Red;
                     break;
                 default:break;
             }
-           
+            
             renderer.DrawCircle(center, RingDistance, DrawColor);
             renderer.Draw(new Vector3(top), new Vector3(bottom), Color4.Blue);
             renderer.Draw(new Vector3(left), new Vector3(right), Color4.Blue);


### PR DESCRIPTION
1. Transforms can now be saved to their respective .yaml files, and children segments are also stored in the same file and are loaded with their transforms.
2. Transforms now change color depending on the state of the machine. To continue, the helper UI node is now situated a little closer to the user's perceived origin.

As a test, I did export my project and all position, rotation, and scale attributes were intact.